### PR TITLE
Fix lifecycle hooking

### DIFF
--- a/src/components/synth/LFOModule.vue
+++ b/src/components/synth/LFOModule.vue
@@ -66,7 +66,6 @@ onMounted(async () => {
         gain: 1.0
     })
     node.gain.connect(context.destination) // or modulate something
+    useModuleLifecycle(node)
 })
-
-useModuleLifecycle(node)
 </script>

--- a/src/components/synth/NoiseGenerator.vue
+++ b/src/components/synth/NoiseGenerator.vue
@@ -49,7 +49,6 @@ onMounted(async () => {
     node = engine.createNoiseNode()
     node.gain.gain.setValueAtTime(noiseLevel.value, context.currentTime)
     node.gain.connect(context.destination) // or to filter
+    useModuleLifecycle(node)
 })
-
-useModuleLifecycle(node)
 </script>

--- a/src/components/synth/OscilatorModule.vue
+++ b/src/components/synth/OscilatorModule.vue
@@ -61,6 +61,7 @@ onMounted(async () => {
     // Explicit initial sync
     updateFreq()
     updateGain()
+    useModuleLifecycle(node)
 })
 
 const updateFreq = () => {
@@ -71,5 +72,4 @@ const updateGain = () => {
     node?.gain.gain.setValueAtTime(oscGain.value, context.currentTime)
 }
 
-useModuleLifecycle(node)
 </script>

--- a/src/components/synth/VCOModule.vue
+++ b/src/components/synth/VCOModule.vue
@@ -63,7 +63,6 @@ onMounted(async () => {
         gain: 0.5
     })
     node.gain.connect(engine.context.destination) // or to filter
+    useModuleLifecycle(node)
 })
-
-useModuleLifecycle(node)
 </script>


### PR DESCRIPTION
## Summary
- move `useModuleLifecycle` calls inside mounted hooks so they reference created nodes