### PR TITLE
Refactor: remove local node creation

### DIFF
--- a/src/components/synth/NoiseGenerator.vue
+++ b/src/components/synth/NoiseGenerator.vue
@@ -24,14 +24,10 @@
 
 <script setup>
 import SynthPanel from '../SynthPanel.vue'
-import { computed, onMounted } from 'vue'
+import { computed } from 'vue'
 import { useSynthStore } from '../../storage/synthStore'
-import { useSynthEngine } from '../../composables/useSynthEngine'
-import { useModuleLifecycle } from '../../composables/useModuleLifecycle'
 
 const synthStore = useSynthStore()
-const engine = useSynthEngine()
-const context = engine.context
 
 const noiseLevel = computed({
     get: () => synthStore.noiseLevel,
@@ -41,15 +37,4 @@ const noiseLevel = computed({
 const updateNoise = () => {
     synthStore.setMixerLevels(synthStore.vcoLevel, noiseLevel.value)
 }
-
-let node = null
-
-onMounted(async () => {
-    await engine.resume()
-    node = engine.createNoiseNode()
-    node.gain.gain.setValueAtTime(noiseLevel.value, context.currentTime)
-    node.gain.connect(context.destination) // or to filter
-})
-
-useModuleLifecycle(node)
 </script>

--- a/src/components/synth/VCOModule.vue
+++ b/src/components/synth/VCOModule.vue
@@ -35,15 +35,11 @@
 </template>
 
 <script setup>
-import { computed, onMounted } from 'vue'
+import { computed } from 'vue'
 import { useSynthStore } from "../../storage/synthStore";
-import { useSynthEngine } from '../../composables/useSynthEngine'
-import { useModuleLifecycle } from '../../composables/useModuleLifecycle'
 import SynthPanel from '../SynthPanel.vue'
 
-const engine = useSynthEngine()
 const synth = useSynthStore();
-let node = null;
 
 const vcoFrequency = computed({
     get: () => synth.vcoFrequency,
@@ -55,15 +51,4 @@ const vcoWaveform = computed({
     set: (val) => synth.setVcoWaveform(val),
 })
 
-onMounted(async () => {
-    await engine.resume()
-    node = engine.createOscillatorNode({
-        frequency: vcoFrequency.value,
-        type: vcoWaveform.value,
-        gain: 0.5
-    })
-    node.gain.connect(engine.context.destination) // or to filter
-})
-
-useModuleLifecycle(node)
 </script>


### PR DESCRIPTION
## Summary
- drop per-component audio node setup in `NoiseGenerator.vue`
- drop per-component audio node setup in `VCOModule.vue`
- rely on nodes created by the synth store

## Testing
- `yarn lint` *(fails: This package doesn't seem to be present in your lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_686d1f3a473c832689339cdd2f1eecd9