### PR TITLE
Fix duplicate VCA destination connection

### DIFF
--- a/src/components/synth/MasterVolume.vue
+++ b/src/components/synth/MasterVolume.vue
@@ -71,11 +71,10 @@ onMounted(() => {
     bufferL = new Uint8Array(analyserL.frequencyBinCount)
     bufferR = new Uint8Array(analyserR.frequencyBinCount)
 
+    // tap the VCA output for metering
     vcaOut.connect(splitter)
     splitter.connect(analyserL, 0)
     splitter.connect(analyserR, 1)
-    analyserL.connect(context.destination)
-    analyserR.connect(context.destination)
 
     const update = () => {
         analyserL.getByteTimeDomainData(bufferL)


### PR DESCRIPTION
## Summary
- stop routing the MasterVolume analyser nodes to `destination`

## Testing
- `yarn lint` *(fails: package isn't present and yarn install requires network)*

------
https://chatgpt.com/codex/tasks/task_e_687227e178d08326941388a096f32554