### PR TITLE
Use shared nodes from store

### DIFF
--- a/src/components/synth/LFOModule.vue
+++ b/src/components/synth/LFOModule.vue
@@ -1,15 +1,15 @@
 <template>
     <SynthPanel :title="'LFO Modulator'">
         <template #heading>
-            <h3 class="text-center text-wrap text-xl font-medium mb-8 uppercase">
+            <h3
+                class="text-center text-wrap text-xl font-medium mb-8 uppercase"
+            >
                 Low Frequency Oscillator
             </h3>
         </template>
 
         <div class="mb-1">
-            <label class="block text-xs font-semibold mb-1">
-                Frequency
-            </label>
+            <label class="block text-xs font-semibold mb-1"> Frequency </label>
             <input
                 type="range"
                 min="0.1"
@@ -19,15 +19,11 @@
                 @input="() => synth.setLfoFrequency(lfoFrequency)"
                 class="w-full h-[8px] accent-black bg-black/10 rounded-full"
             />
-            <div class="text-center mt-1">
-                {{ lfoFrequency.toFixed(1) }} Hz
-            </div>
+            <div class="text-center mt-1">{{ lfoFrequency.toFixed(1) }} Hz</div>
         </div>
 
         <div>
-            <label class="block text-xs font-semibold mb-1">
-                Waveform
-            </label>
+            <label class="block text-xs font-semibold mb-1"> Waveform </label>
             <select
                 v-model="lfoWaveform"
                 @change="() => synth.setLfoWaveform(lfoWaveform)"
@@ -45,33 +41,20 @@
 <script setup>
 import SynthPanel from '../SynthPanel.vue'
 import {computed, onMounted} from 'vue'
-import {useSynthEngine} from '../../composables/useSynthEngine'
 import {useSynthStore} from '../../storage/synthStore'
-import {useModuleLifecycle} from '../../composables/useModuleLifecycle'
 
 const synth = useSynthStore()
-const engine = useSynthEngine()
-let node = null
-
-const context = engine.context
 
 const lfoFrequency = computed({
     get: () => synth.lfoFrequency,
-    set: (val) => synth.setLfoFrequency(val)
+    set: val => synth.setLfoFrequency(val),
 })
 
 const lfoWaveform = computed({
     get: () => synth.lfoWaveform,
-    set: (val) => synth.setLfoWaveform(val)
+    set: val => synth.setLfoWaveform(val),
 })
 onMounted(async () => {
-    await engine.resume()
-    node = engine.createOscillatorNode({
-        frequency: lfoFrequency.value,
-        type: lfoWaveform.value,
-        gain: 1.0
-    })
-    node.gain.connect(context.destination) // or modulate something
-    useModuleLifecycle(node)
+    await synth.resume()
 })
 </script>

--- a/src/components/synth/NoiseGenerator.vue
+++ b/src/components/synth/NoiseGenerator.vue
@@ -1,13 +1,17 @@
 <template>
     <SynthPanel>
         <template #heading>
-            <h3 class="text-center text-wrap text-xl font-medium mb-4 uppercase">
+            <h3
+                class="text-center text-wrap text-xl font-medium mb-4 uppercase"
+            >
                 Noise Generator
             </h3>
         </template>
 
         <div>
-            <label class="flex flex-row items-center justify-between text-xs font-semibold mb-1">
+            <label
+                class="flex flex-row items-center justify-between text-xs font-semibold mb-1"
+            >
                 Level
                 <span class="text-gray-500">White</span>
             </label>
@@ -30,31 +34,21 @@
 
 <script setup>
 import SynthPanel from '../SynthPanel.vue'
-import { computed, onMounted } from 'vue'
-import { useSynthStore } from '../../storage/synthStore'
-import { useSynthEngine } from '../../composables/useSynthEngine'
-import { useModuleLifecycle } from '../../composables/useModuleLifecycle'
+import {computed, onMounted} from 'vue'
+import {useSynthStore} from '../../storage/synthStore'
 
 const synthStore = useSynthStore()
-const engine = useSynthEngine()
-const context = engine.context
 
 const noiseLevel = computed({
     get: () => synthStore.noiseLevel,
-    set: (val) => synthStore.setMixerLevels(synthStore.vcoLevel, val)
+    set: val => synthStore.setMixerLevels(synthStore.vcoLevel, val),
 })
 
 const updateNoise = () => {
     synthStore.setMixerLevels(synthStore.vcoLevel, noiseLevel.value)
 }
 
-let node = null
-
 onMounted(async () => {
-    await engine.resume()
-    node = engine.createNoiseNode()
-    node.gain.gain.setValueAtTime(noiseLevel.value, context.currentTime)
-    node.gain.connect(context.destination) // or to filter
-    useModuleLifecycle(node)
+    await synthStore.resume()
 })
 </script>

--- a/src/components/synth/VCOModule.vue
+++ b/src/components/synth/VCOModule.vue
@@ -1,15 +1,15 @@
 <template>
     <SynthPanel :title="'VCO'">
         <template #heading>
-            <h3 class="text-center text-wrap text-2xl font-medium mb-8 uppercase">
+            <h3
+                class="text-center text-wrap text-2xl font-medium mb-8 uppercase"
+            >
                 VCO
             </h3>
         </template>
 
         <div class="mb-3">
-            <label class="block text-xs font-semibold mb-1">
-                Frequency
-            </label>
+            <label class="block text-xs font-semibold mb-1"> Frequency </label>
             <input
                 type="range"
                 min="50"
@@ -41,34 +41,23 @@
 </template>
 
 <script setup>
-import { computed, onMounted } from 'vue'
-import { useSynthStore } from "../../storage/synthStore";
-import { useSynthEngine } from '../../composables/useSynthEngine'
-import { useModuleLifecycle } from '../../composables/useModuleLifecycle'
+import {computed, onMounted} from 'vue'
+import {useSynthStore} from '../../storage/synthStore'
 import SynthPanel from '../SynthPanel.vue'
 
-const engine = useSynthEngine()
-const synth = useSynthStore();
-let node = null;
+const synth = useSynthStore()
 
 const vcoFrequency = computed({
     get: () => synth.vcoFrequency,
-    set: (val) => synth.setVcoFrequency(val),
+    set: val => synth.setVcoFrequency(val),
 })
 
 const vcoWaveform = computed({
     get: () => synth.vcoWaveform,
-    set: (val) => synth.setVcoWaveform(val),
+    set: val => synth.setVcoWaveform(val),
 })
 
 onMounted(async () => {
-    await engine.resume()
-    node = engine.createOscillatorNode({
-        frequency: vcoFrequency.value,
-        type: vcoWaveform.value,
-        gain: 0.5
-    })
-    node.gain.connect(engine.context.destination) // or to filter
-    useModuleLifecycle(node)
+    await synth.resume()
 })
 </script>


### PR DESCRIPTION
## Summary
- use store nodes for VCO, LFO and noise
- resume synth on mount instead of instantiating nodes

## Testing
- `yarn lint` *(fails: package doesn't seem to be in lockfile)*
- `yarn test` *(fails: package doesn't seem to be in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_687227d82c9c832692e4adb4ce0818ba