### PR TITLE
Improve synth performance

### DIFF
--- a/src/components/synth/LFOModule.vue
+++ b/src/components/synth/LFOModule.vue
@@ -16,7 +16,6 @@
                 max="15"
                 step="0.1"
                 v-model.number="lfoFrequency"
-                @input="() => synth.setLfoFrequency(lfoFrequency)"
                 class="w-full h-[8px] accent-black bg-black/10 rounded-full"
             />
             <div class="text-center mt-1">{{ lfoFrequency.toFixed(1) }} Hz</div>
@@ -26,7 +25,6 @@
             <label class="block text-xs font-semibold mb-1"> Waveform </label>
             <select
                 v-model="lfoWaveform"
-                @change="() => synth.setLfoWaveform(lfoWaveform)"
                 class="w-full text-[10px] px-3 py-1.5 border border-black bg-yellow-50 font-mono uppercase rounded-sm"
             >
                 <option value="sine">Sine</option>

--- a/src/components/synth/MixerModule.vue
+++ b/src/components/synth/MixerModule.vue
@@ -10,7 +10,6 @@
                     max="1"
                     step="0.01"
                     v-model.number="vcoLevel"
-                    @input="updateLevels"
                     class="w-4 h-24 accent-black bg-gray-200 rounded"
                 />
                 <span class="mt-1 text-[10px]">VCO</span>
@@ -24,7 +23,6 @@
                     max="1"
                     step="0.01"
                     v-model.number="noiseLevel"
-                    @input="updateLevels"
                     class="w-4 h-24 accent-black bg-gray-200 rounded"
                 />
                 <span class="mt-1 text-[10px]">Noise</span>
@@ -72,10 +70,6 @@ const toneLabel = computed(() => {
     if (tone.value > 0.7) return 'Bright'
     return 'Neutral'
 })
-
-const updateLevels = () => {
-    synth.setMixerLevels(vcoLevel.value, noiseLevel.value)
-}
 
 const updateTone = () => {
     const base = 500

--- a/src/components/synth/NoiseGenerator.vue
+++ b/src/components/synth/NoiseGenerator.vue
@@ -21,7 +21,6 @@
                 max="1"
                 step="0.01"
                 v-model.number="noiseLevel"
-                @input="updateNoise"
                 class="w-full h-[8px] accent-black bg-black/10 rounded-full"
             />
         </div>
@@ -43,10 +42,6 @@ const noiseLevel = computed({
     get: () => synthStore.noiseLevel,
     set: val => synthStore.setMixerLevels(synthStore.vcoLevel, val),
 })
-
-const updateNoise = () => {
-    synthStore.setMixerLevels(synthStore.vcoLevel, noiseLevel.value)
-}
 
 onMounted(async () => {
     await synthStore.resume()

--- a/src/components/synth/VCAModule.vue
+++ b/src/components/synth/VCAModule.vue
@@ -22,7 +22,6 @@
                 :step="0.01"
                 :show-labels="false"
                 v-model.number="vcaMode"
-                @input="() => synth.setVcaMode(vcaMode)"
                 class="mx-auto"
             />
 

--- a/src/components/synth/VCFModule.vue
+++ b/src/components/synth/VCFModule.vue
@@ -16,7 +16,6 @@
                 max="10000"
                 step="1"
                 v-model.number="filterCutoff"
-                @input="() => synth.setFilterCutoff(filterCutoff)"
                 class="w-full h-[8px] accent-black bg-black/10 rounded-full"
             />
             <p class="text-center text-xs mt-1 text-gray-700">
@@ -30,7 +29,6 @@
             </label>
             <select
                 v-model="filterType"
-                @change="() => synth.setFilterType(filterType)"
                 class="w-full text-[10px] px-3 py-1.5 border border-black bg-yellow-50 font-mono uppercase rounded-sm"
             >
                 <option value="lowpass">Low-Pass</option>
@@ -49,7 +47,6 @@
                 max="20"
                 step="0.1"
                 v-model.number="filterResonance"
-                @input="() => synth.setFilterResonance(filterResonance)"
                 class="w-full h-[8px] accent-black bg-black/10 rounded-full"
             />
         </div>

--- a/src/components/synth/VCOModule.vue
+++ b/src/components/synth/VCOModule.vue
@@ -16,7 +16,6 @@
                 max="2000"
                 step="1"
                 v-model.number="vcoFrequency"
-                @input="() => synth.setVcoFrequency(vcoFrequency)"
                 class="w-full h-[8px] accent-black bg-black/10 rounded-full"
             />
             <p class="text-center text-xs mt-1 text-gray-700">
@@ -28,7 +27,6 @@
             <label class="block text-xs font-semibold mb-1">Waveform</label>
             <select
                 v-model="vcoWaveform"
-                @change="() => synth.setVcoWaveform(vcoWaveform)"
                 class="w-full text-[10px] px-3 py-1.5 border border-black bg-yellow-50 font-mono uppercase rounded-sm"
             >
                 <option value="sine">Sine</option>


### PR DESCRIPTION
## Summary
- lazily create audio nodes when parameters are first used
- remove redundant slider callbacks
- pause level meter updates when the page is hidden