### PR TITLE
Fix patch panel integration

### DIFF
--- a/src/components/synth/LFOModule.vue
+++ b/src/components/synth/LFOModule.vue
@@ -1,6 +1,15 @@
 <template>
     <SynthPanel :title="'LFO Modulator'">
         <template #heading>
+            <section class="flex flex-row items-center justify-end px-8 mb-8">
+                <JackPanel
+                    :count="1"
+                    type="output"
+                    :module-id="id"
+                    :connected="connectedOutputs"
+                    @patch="handlePatch"
+                />
+            </section>
             <h3
                 class="text-center text-wrap text-xl font-medium mb-8 uppercase"
             >
@@ -38,10 +47,32 @@
 
 <script setup>
 import SynthPanel from '../SynthPanel.vue'
-import {computed, onMounted} from 'vue'
+import JackPanel from '../JackPanel.vue'
+import {computed, onMounted, onUnmounted} from 'vue'
 import {useSynthStore} from '../../storage/synthStore'
+import {useModuleRegistry} from '../../composables/useModuleRegistry'
+import {usePatchStore} from '../../storage/patchStore'
 
 const synth = useSynthStore()
+const registry = useModuleRegistry()
+const patchStore = usePatchStore()
+const id = 'lfo-module'
+
+const getOutputNode = () => synth.getLFOOutputNode?.()
+
+onMounted(() => {
+    registry.register(id, { id, getOutputNode })
+})
+
+onUnmounted(() => {
+    registry.unregister(id)
+})
+
+const connectedOutputs = computed(() =>
+    patchStore
+        .getConnectionsFor(id, true)
+        .map(p => p.from.index)
+)
 
 const lfoFrequency = computed({
     get: () => synth.lfoFrequency,
@@ -55,4 +86,15 @@ const lfoWaveform = computed({
 onMounted(async () => {
     await synth.resume()
 })
+
+const handlePatch = ({ type, index }) => {
+    if (type === 'output') {
+        const from = registry.get(id)
+        const to = registry.get('vca-module')
+
+        if (from && to) {
+            patchStore.togglePatch(from, index, to, 0)
+        }
+    }
+}
 </script>

--- a/src/components/synth/NoiseGenerator.vue
+++ b/src/components/synth/NoiseGenerator.vue
@@ -1,6 +1,15 @@
 <template>
     <SynthPanel>
         <template #heading>
+            <section class="flex flex-row items-center justify-end px-8 mb-4">
+                <JackPanel
+                    :count="1"
+                    type="output"
+                    :module-id="id"
+                    :connected="connectedOutputs"
+                    @patch="handlePatch"
+                />
+            </section>
             <h3
                 class="text-center text-wrap text-xl font-medium mb-4 uppercase"
             >
@@ -33,10 +42,32 @@
 
 <script setup>
 import SynthPanel from '../SynthPanel.vue'
-import {computed, onMounted} from 'vue'
+import JackPanel from '../JackPanel.vue'
+import {computed, onMounted, onUnmounted} from 'vue'
 import {useSynthStore} from '../../storage/synthStore'
+import {useModuleRegistry} from '../../composables/useModuleRegistry'
+import {usePatchStore} from '../../storage/patchStore'
 
 const synthStore = useSynthStore()
+const registry = useModuleRegistry()
+const patchStore = usePatchStore()
+const id = 'noise-module'
+
+const getOutputNode = () => synthStore.getNoiseOutputNode?.()
+
+onMounted(() => {
+    registry.register(id, { id, getOutputNode })
+})
+
+onUnmounted(() => {
+    registry.unregister(id)
+})
+
+const connectedOutputs = computed(() =>
+    patchStore
+        .getConnectionsFor(id, true)
+        .map(p => p.from.index)
+)
 
 const noiseLevel = computed({
     get: () => synthStore.noiseLevel,
@@ -46,4 +77,15 @@ const noiseLevel = computed({
 onMounted(async () => {
     await synthStore.resume()
 })
+
+const handlePatch = ({ type, index }) => {
+    if (type === 'output') {
+        const from = registry.get(id)
+        const to = registry.get('vcf-module')
+
+        if (from && to) {
+            patchStore.togglePatch(from, index, to, 0)
+        }
+    }
+}
 </script>

--- a/src/components/synth/VCAModule.vue
+++ b/src/components/synth/VCAModule.vue
@@ -49,13 +49,19 @@ import {useModuleRegistry} from "../../composables/useModuleRegistry";
 
 const synth = useSynthStore();
 const registry = useModuleRegistry();
+const patchStore = usePatchStore();
+const id = 'vca-module';
 
-const getOutputNode = (index) => {
-    return synth.getVcoOutputNode?.(index); // or use direct reference
+const getOutputNode = () => {
+    return synth.getVCAOutputNode?.()
+};
+
+const getInputNode = () => {
+    return synth.getVCAInputNode?.()
 };
 
 onMounted(() => {
-    registry.register(id, { id, getOutputNode });
+    registry.register(id, { id, getInputNode, getOutputNode });
 });
 
 onUnmounted(() => {
@@ -91,8 +97,6 @@ const modeLabel = computed(() => {
     return `${Math.round(vcaMode.value * 100)}% Blend`
 })
 
-const patchStore = usePatchStore();
-const id = 'vca-module';
 
 const connectedInputs = computed(() =>
     patchStore
@@ -102,8 +106,8 @@ const connectedInputs = computed(() =>
 
 const handlePatch = ({ type, index }) => {
     if (type === 'input') {
-        const fromModule = registry.get('vca-module');
-        const toModule = registry.get('vco-module');
+        const fromModule = registry.get('vco-module');
+        const toModule = registry.get('vca-module');
 
         if (fromModule && toModule) {
             patchStore.togglePatch(fromModule, 0, toModule, index);

--- a/src/components/synth/VCFModule.vue
+++ b/src/components/synth/VCFModule.vue
@@ -1,6 +1,22 @@
 <template>
     <SynthPanel>
         <template #heading>
+            <section class="flex flex-row items-center justify-between px-8 mb-8">
+                <JackPanel
+                    :count="1"
+                    type="input"
+                    :module-id="id"
+                    :connected="connectedInputs"
+                    @patch="handlePatch"
+                />
+                <JackPanel
+                    :count="1"
+                    type="output"
+                    :module-id="id"
+                    :connected="connectedOutputs"
+                    @patch="handlePatch"
+                />
+            </section>
             <h3 class="text-center text-wrap text-xl font-medium mb-8 uppercase">
                 VCF
             </h3>
@@ -54,11 +70,40 @@
 </template>
 
 <script setup>
-import { computed, onMounted } from 'vue'
+import { computed, onMounted, onUnmounted } from 'vue'
 import { useSynthStore } from '../../storage/synthStore'
+import { useModuleRegistry } from '../../composables/useModuleRegistry'
+import { usePatchStore } from '../../storage/patchStore'
 import SynthPanel from "../SynthPanel.vue";
+import JackPanel from '../JackPanel.vue'
 
 const synth = useSynthStore()
+const registry = useModuleRegistry()
+const patchStore = usePatchStore()
+const id = 'vcf-module'
+
+const getInputNode = () => synth.getVCFInputNode?.()
+const getOutputNode = () => synth.getVCFOutputNode?.()
+
+onMounted(() => {
+    registry.register(id, { id, getInputNode, getOutputNode })
+})
+
+onUnmounted(() => {
+    registry.unregister(id)
+})
+
+const connectedInputs = computed(() =>
+    patchStore
+        .getConnectionsFor(id, false)
+        .map(p => p.to.index)
+)
+
+const connectedOutputs = computed(() =>
+    patchStore
+        .getConnectionsFor(id, true)
+        .map(p => p.from.index)
+)
 
 const filterCutoff = computed({
     get: () => synth.filterCutoff,
@@ -78,4 +123,22 @@ const filterType = computed({
 onMounted(() => {
     // Optional: synth.initVCF() if not globally initialized
 })
+
+const handlePatch = ({ type, index }) => {
+    if (type === 'input') {
+        const from = registry.get('vco-module')
+        const to = registry.get(id)
+
+        if (from && to) {
+            patchStore.togglePatch(from, 0, to, index)
+        }
+    } else if (type === 'output') {
+        const from = registry.get(id)
+        const to = registry.get('vca-module')
+
+        if (from && to) {
+            patchStore.togglePatch(from, index, to, 0)
+        }
+    }
+}
 </script>

--- a/src/components/synth/VCOModule.vue
+++ b/src/components/synth/VCOModule.vue
@@ -1,6 +1,16 @@
 <template>
     <SynthPanel :title="'VCO'">
         <template #heading>
+            <section class="flex flex-row items-center justify-between px-8 mb-8">
+                <div></div>
+                <JackPanel
+                    :count="1"
+                    type="output"
+                    :module-id="id"
+                    :connected="connectedOutputs"
+                    @patch="handlePatch"
+                />
+            </section>
             <h3
                 class="text-center text-wrap text-2xl font-medium mb-8 uppercase"
             >
@@ -39,11 +49,35 @@
 </template>
 
 <script setup>
-import {computed, onMounted} from 'vue'
+import {computed, onMounted, onUnmounted} from 'vue'
 import {useSynthStore} from '../../storage/synthStore'
+import {useModuleRegistry} from '../../composables/useModuleRegistry'
+import {usePatchStore} from '../../storage/patchStore'
 import SynthPanel from '../SynthPanel.vue'
+import JackPanel from '../JackPanel.vue'
 
 const synth = useSynthStore()
+const registry = useModuleRegistry()
+const patchStore = usePatchStore()
+const id = 'vco-module'
+
+const getOutputNode = (index) => {
+    return synth.getVCOOutputNode?.(index)
+}
+
+onMounted(() => {
+    registry.register(id, { id, getOutputNode })
+})
+
+onUnmounted(() => {
+    registry.unregister(id)
+})
+
+const connectedOutputs = computed(() =>
+    patchStore
+        .getConnectionsFor(id, true)
+        .map(p => p.from.index)
+)
 
 const vcoFrequency = computed({
     get: () => synth.vcoFrequency,
@@ -58,4 +92,15 @@ const vcoWaveform = computed({
 onMounted(async () => {
     await synth.resume()
 })
+
+const handlePatch = ({ type, index }) => {
+    if (type === 'output') {
+        const fromModule = registry.get('vco-module')
+        const toModule = registry.get('vca-module')
+
+        if (fromModule && toModule) {
+            patchStore.togglePatch(fromModule, index, toModule, 0)
+        }
+    }
+}
 </script>

--- a/src/storage/synthStore.js
+++ b/src/storage/synthStore.js
@@ -44,6 +44,36 @@ export const useSynthStore = defineStore('synth', () => {
         return vcaGainNode
     }
 
+    const getVCAInputNode = () => {
+        ensureVCA()
+        return vcaGainNode
+    }
+
+    const getVCOOutputNode = () => {
+        ensureVCO()
+        return vcoOutGain
+    }
+
+    const getVCFInputNode = () => {
+        ensureVCF()
+        return filterNode
+    }
+
+    const getVCFOutputNode = () => {
+        ensureVCF()
+        return filterNode
+    }
+
+    const getNoiseOutputNode = () => {
+        ensureNoise()
+        return noiseOutGain
+    }
+
+    const getLFOOutputNode = () => {
+        ensureLFO()
+        return lfoOutGain
+    }
+
     const initVCF = () => {
         filterNode = engine.createFilterNode({
             type: filterType.value,
@@ -227,7 +257,14 @@ export const useSynthStore = defineStore('synth', () => {
         setLfoFrequency, setLfoWaveform,
         setFilterCutoff, setFilterResonance, setFilterType,
         setMixerLevels, setVcaMode,
-        triggerEnvelope: triggerVCAEnvelope, getVCAOutputNode,
+        triggerEnvelope: triggerVCAEnvelope,
+        getVCAOutputNode,
+        getVCAInputNode,
+        getVCOOutputNode,
+        getVCFInputNode,
+        getVCFOutputNode,
+        getNoiseOutputNode,
+        getLFOOutputNode,
 
         // Lifecycle
         resume,


### PR DESCRIPTION
- expose VCO and VCA nodes from the synth store
- register VCO/VCA modules with the module registry
- wire up patch jacks to toggle connections between VCO and VCA
- hook up remaining modules to the patch store for basic routing