### PR TITLE
Fix flex class spacing in SynthPanel

### DIFF
--- a/src/components/SynthPanel.vue
+++ b/src/components/SynthPanel.vue
@@ -4,7 +4,7 @@
         tracking-wide space-y-2"
     >
         <slot name="heading" />
-        <div class="flex- 1 space-y-3">
+        <div class="flex-1 space-y-3">
             <slot />
         </div>
     </div>


### PR DESCRIPTION
## Summary
- fix a typo in `SynthPanel.vue` class name

## Testing
- `yarn test` *(fails: package not in lockfile)*
- `yarn install` *(fails: RequestError 403)*

------
https://chatgpt.com/codex/tasks/task_e_6873606ca0308326b064c55b7490e066