### PR TITLE
Add cleanup for patch connections and synth teardown

### DIFF
--- a/src/components/WorkspacePanel.vue
+++ b/src/components/WorkspacePanel.vue
@@ -37,7 +37,7 @@
 
 <script setup>
 import { useSynthStore } from '../storage/synthStore';
-import {onMounted, ref} from 'vue';
+import {onMounted, onUnmounted, ref} from 'vue';
 import EnvelopeGenerator from "./synth/EnvelopeGenerator.vue";
 import NoiseGenerator from "./synth/NoiseGenerator.vue";
 import SliderKeyboard from "./synth/SliderKeyboard.vue";
@@ -71,6 +71,10 @@ const unlock = async () => {
         console.warn('Failed to resume AudioContext:', e);
     }
 };
+
+onUnmounted(() => {
+    synth.destroySynth()
+})
 </script>
 
 <style>

--- a/src/components/synth/LFOModule.vue
+++ b/src/components/synth/LFOModule.vue
@@ -73,6 +73,7 @@ onMounted(() => {
 })
 
 onUnmounted(() => {
+    patchStore.removeConnectionsForModule(id)
     registry.unregister(id)
 })
 

--- a/src/components/synth/NoiseGenerator.vue
+++ b/src/components/synth/NoiseGenerator.vue
@@ -60,6 +60,7 @@ onMounted(() => {
 })
 
 onUnmounted(() => {
+    patchStore.removeConnectionsForModule(id)
     registry.unregister(id)
 })
 

--- a/src/components/synth/VCAModule.vue
+++ b/src/components/synth/VCAModule.vue
@@ -70,6 +70,7 @@ onMounted(() => {
 });
 
 onUnmounted(() => {
+    patchStore.removeConnectionsForModule(id)
     registry.unregister(id);
 });
 

--- a/src/components/synth/VCFModule.vue
+++ b/src/components/synth/VCFModule.vue
@@ -91,6 +91,7 @@ onMounted(() => {
 })
 
 onUnmounted(() => {
+    patchStore.removeConnectionsForModule(id)
     registry.unregister(id)
 })
 

--- a/src/components/synth/VCOModule.vue
+++ b/src/components/synth/VCOModule.vue
@@ -75,6 +75,7 @@ onMounted(() => {
 })
 
 onUnmounted(() => {
+    patchStore.removeConnectionsForModule(id)
     registry.unregister(id)
 })
 

--- a/src/storage/patchStore.js
+++ b/src/storage/patchStore.js
@@ -44,6 +44,30 @@ export const usePatchStore = defineStore('patch', () => {
         }
     };
 
+    const removeConnectionsForModule = (moduleId) => {
+        const toRemove = patches.value.filter(
+            (p) => p.from.id === moduleId || p.to.id === moduleId
+        );
+
+        toRemove.forEach((p) => {
+            const fromModule = registry.get(p.from.id);
+            const toModule = registry.get(p.to.id);
+            if (fromModule && toModule) {
+                try {
+                    const out = fromModule.getOutputNode(p.from.index);
+                    const inp = toModule.getInputNode(p.to.index);
+                    out?.disconnect?.(inp);
+                } catch (e) {
+                    console.error('Patch cleanup failed:', e);
+                }
+            }
+        });
+
+        patches.value = patches.value.filter(
+            (p) => p.from.id !== moduleId && p.to.id !== moduleId
+        );
+    };
+
     const togglePatch = (fromModule, fromIndex, toModule, toIndex) => {
         const exists = patches.value.find(
             p =>
@@ -107,6 +131,7 @@ export const usePatchStore = defineStore('patch', () => {
         disconnectNodes,
         togglePatch,
         getConnectionsFor,
-        selectJack
+        selectJack,
+        removeConnectionsForModule
     };
 });


### PR DESCRIPTION
## Summary
- clean up patches when modules unmount
- tear down synth engine when the workspace panel unmounts

## Testing
- `yarn lint` *(fails: package missing from lockfile)*
- `yarn test` *(fails: package missing from lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6873754432808326baec09421b3f4e2e