### PR TITLE
Add patch cable overlay and input module jacks

### DIFF
--- a/src/components/JackPanel.vue
+++ b/src/components/JackPanel.vue
@@ -8,6 +8,7 @@
                     'bg-yellow-400': connected.includes(i - 1),
                     'bg-gray-800': !connected.includes(i - 1)
                 }"
+                :id="`${moduleId}-${type}-${i - 1}`"
                 class="w-3 h-3 rounded-full cursor-pointer border border-gray-600"
                 @click="handleClick(i - 1)"
             />

--- a/src/components/PatchCables.vue
+++ b/src/components/PatchCables.vue
@@ -1,0 +1,48 @@
+<template>
+    <svg class="absolute inset-0 pointer-events-none" xmlns="http://www.w3.org/2000/svg">
+        <line
+            v-for="(patch, idx) in lines"
+            :key="idx"
+            :x1="patch.x1"
+            :y1="patch.y1"
+            :x2="patch.x2"
+            :y2="patch.y2"
+            stroke="#ffcc00"
+            stroke-width="2"
+        />
+    </svg>
+</template>
+
+<script setup>
+import { onMounted, watch, ref } from 'vue'
+import { usePatchStore } from '../storage/patchStore'
+
+const patchStore = usePatchStore()
+const lines = ref([])
+
+const getPosition = (moduleId, type, index) => {
+    const el = document.getElementById(`${moduleId}-${type}-${index}`)
+    if (!el) return { x: 0, y: 0 }
+    const rect = el.getBoundingClientRect()
+    return { x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 }
+}
+
+const updateLines = () => {
+    lines.value = patchStore.patches.map(p => {
+        const from = getPosition(p.from.id, 'output', p.from.index)
+        const to = getPosition(p.to.id, 'input', p.to.index)
+        return { x1: from.x, y1: from.y, x2: to.x, y2: to.y }
+    })
+}
+
+watch(
+    () => patchStore.patches,
+    () => updateLines(),
+    { deep: true }
+)
+
+onMounted(() => {
+    updateLines()
+    window.addEventListener('resize', updateLines)
+})
+</script>

--- a/src/components/WorkspacePanel.vue
+++ b/src/components/WorkspacePanel.vue
@@ -32,6 +32,7 @@
         <div class="flex flex-col gap-6 py-6">
             <div class=""><SliderKeyboard /></div>
         </div>
+        <PatchCables />
     </div>
 </template>
 
@@ -49,6 +50,7 @@ import VCAModule from "./synth/VCAModule.vue";
 import InputModule from "./synth/InputModule.vue";
 import MasterVolume from "./synth/MasterVolume.vue";
 import SynthPanel from "./SynthPanel.vue";
+import PatchCables from "./PatchCables.vue";
 
 const audioReady = ref(false);
 const synth = useSynthStore();

--- a/src/storage/patchStore.js
+++ b/src/storage/patchStore.js
@@ -14,14 +14,14 @@ export const usePatchStore = defineStore('patch', () => {
         if (output && input) {
             try {
                 output.connect(input);
-                patches.value.push({
-                    from: { id: fromModule.id, index: fromIndex },
-                    to: { id: toModule.id, index: toIndex }
-                });
             } catch (e) {
                 console.error('Patch failed:', e);
             }
         }
+        patches.value.push({
+            from: { id: fromModule.id, index: fromIndex },
+            to: { id: toModule.id, index: toIndex }
+        });
     };
 
     const disconnectNodes = (fromModule, fromIndex, toModule, toIndex) => {
@@ -31,17 +31,17 @@ export const usePatchStore = defineStore('patch', () => {
         if (output && input) {
             try {
                 output.disconnect(input);
-                patches.value = patches.value.filter(
-                    p =>
-                        !(p.from.id === fromModule.id &&
-                            p.from.index === fromIndex &&
-                            p.to.id === toModule.id &&
-                            p.to.index === toIndex)
-                );
             } catch (e) {
                 console.error('Unpatch failed:', e);
             }
         }
+        patches.value = patches.value.filter(
+            p =>
+                !(p.from.id === fromModule.id &&
+                    p.from.index === fromIndex &&
+                    p.to.id === toModule.id &&
+                    p.to.index === toIndex)
+        );
     };
 
     const removeConnectionsForModule = (moduleId) => {


### PR DESCRIPTION
## Summary
- allow patch cables to be drawn by introducing `PatchCables.vue`
- expose DOM ids for each jack
- register output jacks on the input module
- track patches even when audio nodes are missing
- show cables in the workspace panel

## Testing
- `yarn format` *(fails: package missing)*
- `yarn test` *(fails: package missing)*

------
https://chatgpt.com/codex/tasks/task_e_68738317a20c8326a3952a29a2c0a499