### PR TITLE
Add input node support for patching

### DIFF
--- a/src/components/synth/LFOModule.vue
+++ b/src/components/synth/LFOModule.vue
@@ -56,10 +56,10 @@
 <script setup>
 import SynthPanel from '../SynthPanel.vue'
 import JackPanel from '../JackPanel.vue'
-import {computed, onMounted, onUnmounted} from 'vue'
-import {useSynthStore} from '../../storage/synthStore'
-import {useModuleRegistry} from '../../composables/useModuleRegistry'
-import {usePatchStore} from '../../storage/patchStore'
+import { computed, onMounted, onUnmounted } from 'vue'
+import { useSynthStore } from '../../storage/synthStore'
+import { useModuleRegistry } from '../../composables/useModuleRegistry'
+import { usePatchStore } from '../../storage/patchStore'
 
 const synth = useSynthStore()
 const registry = useModuleRegistry()
@@ -67,9 +67,10 @@ const patchStore = usePatchStore()
 const id = 'lfo-module'
 
 const getOutputNode = () => synth.getLFOOutputNode?.()
+const getInputNode = () => synth.getLFOInputNode?.()
 
 onMounted(() => {
-    registry.register(id, { id, getOutputNode })
+    registry.register(id, { id, getInputNode, getOutputNode })
 })
 
 onUnmounted(() => {

--- a/src/components/synth/VCOModule.vue
+++ b/src/components/synth/VCOModule.vue
@@ -54,10 +54,10 @@
 </template>
 
 <script setup>
-import {computed, onMounted, onUnmounted} from 'vue'
-import {useSynthStore} from '../../storage/synthStore'
-import {useModuleRegistry} from '../../composables/useModuleRegistry'
-import {usePatchStore} from '../../storage/patchStore'
+import { computed, onMounted, onUnmounted } from 'vue'
+import { useSynthStore } from '../../storage/synthStore'
+import { useModuleRegistry } from '../../composables/useModuleRegistry'
+import { usePatchStore } from '../../storage/patchStore'
 import SynthPanel from '../SynthPanel.vue'
 import JackPanel from '../JackPanel.vue'
 
@@ -70,8 +70,12 @@ const getOutputNode = (index) => {
     return synth.getVCOOutputNode?.(index)
 }
 
+const getInputNode = (index) => {
+    return synth.getVCOInputNode?.(index)
+}
+
 onMounted(() => {
-    registry.register(id, { id, getOutputNode })
+    registry.register(id, { id, getInputNode, getOutputNode })
 })
 
 onUnmounted(() => {

--- a/src/storage/synthStore.js
+++ b/src/storage/synthStore.js
@@ -54,6 +54,11 @@ export const useSynthStore = defineStore('synth', () => {
         return vcoOutGain
     }
 
+    const getVCOInputNode = () => {
+        ensureVCO()
+        return vcoOsc?.frequency || null
+    }
+
     const getVCFInputNode = () => {
         ensureVCF()
         return filterNode
@@ -72,6 +77,11 @@ export const useSynthStore = defineStore('synth', () => {
     const getLFOOutputNode = () => {
         ensureLFO()
         return lfoOutGain
+    }
+
+    const getLFOInputNode = () => {
+        ensureLFO()
+        return lfoOsc?.frequency || null
     }
 
     const initVCF = () => {
@@ -280,10 +290,12 @@ export const useSynthStore = defineStore('synth', () => {
         triggerEnvelope: triggerVCAEnvelope,
         getVCAOutputNode,
         getVCAInputNode,
+        getVCOInputNode,
         getVCOOutputNode,
         getVCFInputNode,
         getVCFOutputNode,
         getNoiseOutputNode,
+        getLFOInputNode,
         getLFOOutputNode,
 
         // Lifecycle


### PR DESCRIPTION
## Summary
- add VCO and LFO input nodes in synth store
- register new input nodes in VCO and LFO modules so patches connect correctly

## Testing
- `yarn lint` *(fails: This package doesn't seem to be present in your lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68738bb0587c83268e1c75b79709f9aa