### PR TITLE
Add envelope parameter setters

### DIFF
--- a/src/components/synth/EnvelopeGenerator.vue
+++ b/src/components/synth/EnvelopeGenerator.vue
@@ -84,12 +84,12 @@ const synth = useSynthStore()
 
 const envelopeAttack = computed({
     get: () => synth.envelopeAttack,
-    set: (val) => synth.envelopeAttack = val
+    set: (val) => synth.setEnvelopeAttack(val)
 })
 
 const envelopeDecay = computed({
     get: () => synth.envelopeDecay,
-    set: (val) => synth.envelopeDecay = val
+    set: (val) => synth.setEnvelopeDecay(val)
 })
 
 const triggerEnvelope = () => {

--- a/src/storage/synthStore.js
+++ b/src/storage/synthStore.js
@@ -242,6 +242,14 @@ export const useSynthStore = defineStore('synth', () => {
         lfoOutGain?.gain.setValueAtTime(mode, ctx.currentTime)
     }
 
+    const setEnvelopeAttack = (val) => {
+        envelopeAttack.value = val
+    }
+
+    const setEnvelopeDecay = (val) => {
+        envelopeDecay.value = val
+    }
+
     // === Envelope Action ===
     const triggerVCAEnvelope = () => {
         ensureVCA()
@@ -287,6 +295,7 @@ export const useSynthStore = defineStore('synth', () => {
         setLfoFrequency, setLfoWaveform,
         setFilterCutoff, setFilterResonance, setFilterType,
         setMixerLevels, setVcaMode,
+        setEnvelopeAttack, setEnvelopeDecay,
         triggerEnvelope: triggerVCAEnvelope,
         getVCAOutputNode,
         getVCAInputNode,


### PR DESCRIPTION
## Summary
- add `setEnvelopeAttack` and `setEnvelopeDecay` to synth store
- use the new actions in `EnvelopeGenerator` component

## Testing
- `yarn lint` *(fails: package not in lockfile)*
- `yarn test` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68739700122883268b6f2f2e19921571