### PR TITLE
Fix resize listener cleanup

### DIFF
--- a/src/components/PatchCables.vue
+++ b/src/components/PatchCables.vue
@@ -17,7 +17,7 @@
 </template>
 
 <script setup>
-import {onMounted, watch, ref} from 'vue'
+import { onMounted, onUnmounted, watch, ref } from 'vue'
 import { usePatchStore } from '../storage/patchStore'
 
 const patchStore = usePatchStore();
@@ -56,5 +56,9 @@ watch(
 onMounted(() => {
     updateLines()
     window.addEventListener('resize', updateLines)
+})
+
+onUnmounted(() => {
+    window.removeEventListener('resize', updateLines)
 })
 </script>


### PR DESCRIPTION
## Summary
- ensure resize listener is removed when `PatchCables` unmounts

## Testing
- `yarn test` *(fails: RequestError due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687398acd6f48326bc09c8caf0ee1128