### PR TITLE
Make mixer module independent

### DIFF
--- a/src/components/synth/MixerModule.vue
+++ b/src/components/synth/MixerModule.vue
@@ -1,7 +1,6 @@
 <template>
-    <SynthPanel title="Mixer">
+    <SynthPanel :id="id" title="Mixer">
         <div class="flex flex-col justify-around h-[140px]">
-
             <!-- VCO -->
             <div class="flex flex-col items-center">
                 <input
@@ -27,53 +26,57 @@
                 />
                 <span class="mt-1 text-[10px]">Noise</span>
             </div>
-
-            <!-- Tone -->
-            <div class="flex flex-col items-center w-20">
-                <input
-                    type="range"
-                    min="0"
-                    max="1"
-                    step="0.01"
-                    v-model.number="tone"
-                    @input="updateTone"
-                    class="w-full accent-orange-600"
-                />
-                <span class="mt-1 text-[10px]">{{ toneLabel }}</span>
-            </div>
-
         </div>
+        <JackPanel
+            class="mt-4"
+            :count="1"
+            type="output"
+            :module-id="id"
+            :connected="connectedOutputs"
+            @patch="handlePatch"
+        />
     </SynthPanel>
 </template>
 
 <script setup>
 import SynthPanel from '../SynthPanel.vue'
-import { computed, ref } from 'vue'
-import { useSynthStore } from '../../storage/synthStore'
+import JackPanel from '../JackPanel.vue'
+import {computed, onMounted, onUnmounted} from 'vue'
+import {useSynthStore} from '../../storage/synthStore'
+import {usePatchStore} from '../../storage/patchStore'
+import {useModuleRegistry} from '../../composables/useModuleRegistry'
 
 const synth = useSynthStore()
+const patchStore = usePatchStore()
+const registry = useModuleRegistry()
+const id = 'mixer-module'
+
+const getOutputNode = () => synth.getMixerOutputNode?.()
+
+onMounted(() => {
+    registry.register(id, {id, getOutputNode})
+})
+
+onUnmounted(() => {
+    patchStore.removeConnectionsForModule(id)
+    registry.unregister(id)
+})
 
 const vcoLevel = computed({
     get: () => synth.vcoLevel,
-    set: (val) => synth.setMixerLevels(val, synth.noiseLevel)
+    set: val => synth.setMixerLevels(val, synth.noiseLevel),
 })
 
 const noiseLevel = computed({
     get: () => synth.noiseLevel,
-    set: (val) => synth.setMixerLevels(synth.vcoLevel, val)
+    set: val => synth.setMixerLevels(synth.vcoLevel, val),
 })
 
-const tone = ref(0.5)
+const connectedOutputs = computed(() =>
+    patchStore.getConnectionsFor(id, true).map(p => p.from.index)
+)
 
-const toneLabel = computed(() => {
-    if (tone.value < 0.3) return 'Dark'
-    if (tone.value > 0.7) return 'Bright'
-    return 'Neutral'
-})
-
-const updateTone = () => {
-    const base = 500
-    const spread = 8000
-    synth.setFilterCutoff(base + tone.value * spread)
+const handlePatch = jack => {
+    patchStore.selectJack(jack)
 }
 </script>


### PR DESCRIPTION
## Summary
- connect VCO and noise through a mixer node before the filter
- expose mixer output for patching and add MixerModule jacks
- update destroy routine for new node
- format code

## Testing
- `npm run lint`
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873ccd6809c83268e31a973b2df87f5