### PR TITLE
Add oscilloscope module

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ The interface exposes a simplified set of modules which can be patched together:
 - **Envelope Generator** – attack and decay sliders and a manual trigger button.
 - **VCA** – gain stage whose behaviour is set with the *Mix Mode* slider.
 - **Inverter** – simple phase‑inverting utility.
-- **Master Output** – final stage with oscilloscope display.
+- **Master Output** – final stage routing audio to the speakers.
+- **Oscilloscope** – real-time waveform display.
 - **Master Volume** – stereo level meter and output level control.
 - **Input Module** – placeholder sliders representing external sources.
 - **Slider Keyboard** – touch strip that sets the VCO frequency and triggers the envelope.

--- a/src/components/WorkspacePanel.vue
+++ b/src/components/WorkspacePanel.vue
@@ -19,7 +19,7 @@
                 <div class=""><VCFModule /></div>
                 <div class=""><SynthPanel /></div>
             </div>
-            <div class="grid grid-cols-2 sm:grid-cols-5 gap-4 mx-4">
+            <div class="grid grid-cols-2 sm:grid-cols-6 gap-4 mx-4">
                 <div class=""><MixerModule /></div>
                 <div class=""><EnvelopeGenerator /></div>
                 <div class="flex flex-col gap-4">
@@ -27,6 +27,7 @@
                 </div>
                 <div class=""><VCAModule /></div>
                 <div class=""><MasterOutput /></div>
+                <div class=""><Oscilloscope /></div>
             </div>
         </div>
 
@@ -50,6 +51,7 @@ import MixerModule from './modules/MixerModule.vue';
 import SynthPanel from './modules/SynthPanel.vue';
 import PatchCables from './PatchCables.vue';
 import MasterOutput from "./modules/MasterOutput.vue";
+import Oscilloscope from "./modules/Oscilloscope.vue";
 
 const audioReady = ref(false);
 const synth = useSynthStore();

--- a/src/components/modules/MasterOutput.vue
+++ b/src/components/modules/MasterOutput.vue
@@ -6,14 +6,7 @@
             </h3>
         </template>
 
-        <div class="relative w-full aspect-video h-auto bg-stone-700 mx-auto rounded-md shadow-[inset_0_0_25px_rgba(0,0,0,0.5)]">
-            <div class="absolute inset-[1%] bg-black rounded-lg shadow-inner p-1">
-                <canvas
-                    ref="scopeCanvas"
-                    class="w-full h-full rounded-md"
-                />
-            </div>
-        </div>
+
 
         <label class="text-xs block mb-1">Master Volume</label>
         <input
@@ -47,7 +40,7 @@
 </template>
 
 <script setup>
-import { ref, onMounted, onUnmounted, computed } from 'vue'
+import { ref, onMounted, onUnmounted } from 'vue'
 import { useSynthEngine } from '../../composables/useSynthEngine'
 import SynthPanel from './SynthPanel.vue'
 import JackPanel from '../JackPanel.vue'
@@ -63,16 +56,13 @@ const context = engine.context
 // Nodes
 const inputGain = context.createGain()
 const masterGain = context.createGain()
-const analyser = context.createAnalyser()
-
-useModuleLifecycle(inputGain, masterGain, analyser)
+useModuleLifecycle(inputGain, masterGain)
 
 const getInputNode = () => inputGain
 
-// Routing: input -> master -> analyser -> speakers
+// Routing: input -> master -> speakers
 inputGain.connect(masterGain)
-masterGain.connect(analyser)
-analyser.connect(context.destination)
+masterGain.connect(context.destination)
 
 // Volume state
 const volume = ref(0.8)
@@ -113,72 +103,7 @@ onMounted(() => {
 
 
 
-// Meter + scope state
-const scopeCanvas = ref(null)
-const pulseLeft = ref(0)
-const pulseRight = ref(0)
-const overloaded = ref(false)
-
-let animationFrame = null
-
-onMounted(() => {
-    const canvas = scopeCanvas.value
-    const ctx = canvas.getContext('2d')
-
-    analyser.fftSize = 1024
-    const bufferLength = analyser.fftSize
-    const dataArray = new Uint8Array(bufferLength)
-
-    const draw = () => {
-        animationFrame = requestAnimationFrame(draw)
-
-        analyser.getByteTimeDomainData(dataArray)
-
-        // Draw scope
-        ctx.fillStyle = 'black'
-        ctx.fillRect(0, 0, canvas.width, canvas.height)
-
-        ctx.lineWidth = 2
-        ctx.strokeStyle = '#4ade80'
-        ctx.beginPath()
-
-        const sliceWidth = canvas.width / bufferLength
-        let x = 0
-
-        for (let i = 0; i < bufferLength; i++) {
-            const v = dataArray[i] / 128.0
-            const y = (v * canvas.height) / 2
-            i === 0 ? ctx.moveTo(x, y) : ctx.lineTo(x, y)
-            x += sliceWidth
-        }
-
-        ctx.lineTo(canvas.width, canvas.height / 2)
-        ctx.stroke()
-
-        // L/R pseudo-RMS from halves
-        const mid = bufferLength / 2
-        const rms = arr =>
-            Math.sqrt(arr.reduce((sum, v) => sum + (v - 128) ** 2, 0) / arr.length)
-
-        pulseLeft.value = Math.min(rms(dataArray.slice(0, mid)) * 2, 255)
-        pulseRight.value = Math.min(rms(dataArray.slice(mid)) * 2, 255)
-
-        // Overload detection
-        overloaded.value = pulseLeft.value > 220 || pulseRight.value > 220
-    }
-
-    draw()
-})
-
 onUnmounted(() => {
-    if (animationFrame) {
-        cancelAnimationFrame(animationFrame)
-    }
-
-    if (scopeCanvas.value) {
-        const ctx = scopeCanvas.value.getContext('2d')
-        ctx.clearRect(0, 0, scopeCanvas.value.width, scopeCanvas.value.height)
-    }
 
     if (vcaOut) {
         try {
@@ -189,17 +114,5 @@ onUnmounted(() => {
 
     inputGain.disconnect()
     masterGain.disconnect()
-    analyser.disconnect()
 })
-
-const getMeterColor = (value) => {
-    if (value > 220) {
-        return '#f87171';
-    }
-    if (value > 140) {
-        return '#facc15';
-    }
-
-    return '#4ade80';
-}
 </script>

--- a/src/components/modules/Oscilloscope.vue
+++ b/src/components/modules/Oscilloscope.vue
@@ -1,0 +1,89 @@
+<template>
+    <SynthPanel>
+        <template #heading>
+            <h3 class="text-center text-wrap text-xl font-medium mb-4 uppercase">
+                Oscilloscope
+            </h3>
+        </template>
+        <div class="relative w-full aspect-video h-auto bg-stone-700 mx-auto rounded-md shadow-[inset_0_0_25px_rgba(0,0,0,0.5)]">
+            <div class="absolute inset-[1%] bg-black rounded-lg shadow-inner p-1">
+                <canvas ref="scopeCanvas" class="w-full h-full rounded-md" />
+            </div>
+        </div>
+    </SynthPanel>
+</template>
+
+<script setup>
+import { ref, onMounted, onUnmounted } from 'vue'
+import { useSynthEngine } from '../../composables/useSynthEngine'
+import { useSynthStore } from '../../storage/synthStore'
+import { useModuleLifecycle } from '../../composables/useModuleLifecycle'
+import SynthPanel from './SynthPanel.vue'
+
+const engine = useSynthEngine()
+const synth = useSynthStore()
+const context = engine.context
+
+const scopeCanvas = ref(null)
+const analyser = context.createAnalyser()
+useModuleLifecycle(analyser)
+
+let vcaOut = null
+let rafId = null
+
+onMounted(() => {
+    vcaOut = synth.getVCAOutputNode?.()
+    if (vcaOut) {
+        try {
+            vcaOut.connect(analyser)
+        } catch {}
+    }
+
+    const canvas = scopeCanvas.value
+    const ctx = canvas.getContext('2d')
+
+    analyser.fftSize = 1024
+    const bufferLength = analyser.fftSize
+    const dataArray = new Uint8Array(bufferLength)
+
+    const draw = () => {
+        rafId = requestAnimationFrame(draw)
+
+        analyser.getByteTimeDomainData(dataArray)
+
+        ctx.fillStyle = 'black'
+        ctx.fillRect(0, 0, canvas.width, canvas.height)
+
+        ctx.lineWidth = 2
+        ctx.strokeStyle = '#4ade80'
+        ctx.beginPath()
+
+        const sliceWidth = canvas.width / bufferLength
+        let x = 0
+
+        for (let i = 0; i < bufferLength; i++) {
+            const v = dataArray[i] / 128.0
+            const y = (v * canvas.height) / 2
+            i === 0 ? ctx.moveTo(x, y) : ctx.lineTo(x, y)
+            x += sliceWidth
+        }
+
+        ctx.lineTo(canvas.width, canvas.height / 2)
+        ctx.stroke()
+    }
+
+    draw()
+})
+
+onUnmounted(() => {
+    if (rafId) {
+        cancelAnimationFrame(rafId)
+    }
+
+    try {
+        vcaOut?.disconnect(analyser)
+    } catch {}
+
+    analyser.disconnect()
+})
+</script>


### PR DESCRIPTION
## Summary
- extract oscilloscope display from MasterOutput into new module
- simplify MasterOutput to just route audio to speakers
- show the Oscilloscope module in the workspace
- document the new module in README

## Testing
- `yarn lint` *(fails: package isn't in lockfile)*
- `yarn test` *(fails: package isn't in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_687c96b8d6f483269ede9adb58f33419