### PR TITLE
Add double click reset for sliders

### DIFF
--- a/src/components/VerticalSlider.vue
+++ b/src/components/VerticalSlider.vue
@@ -10,6 +10,7 @@
             :step="step"
             v-model="value"
             @input="$emit('update:modelValue', +value)"
+            @dblclick="$emit('dblclick')"
             class="absolute origin-center rotate-[-90deg] h-2 rounded accent-black bg-black/10 cursor-pointer"
             :class="!showLabels ? 'w-52' : 'w-40'"
         />
@@ -45,7 +46,7 @@ const props = defineProps({
     },
 });
 
-const emit = defineEmits(['update:modelValue']);
+const emit = defineEmits(['update:modelValue', 'dblclick']);
 const value = ref(props.modelValue);
 
 watch(

--- a/src/components/modules/EnvelopeGenerator.vue
+++ b/src/components/modules/EnvelopeGenerator.vue
@@ -27,6 +27,7 @@
                     :max="1"
                     :step="0.05"
                     :show-labels="false"
+                    @dblclick="synth.resetParam('envelopeAttack')"
                 />
 
                 <label class="block text-xs font-medium mb-1 mt-3">
@@ -69,6 +70,7 @@
                     :max="1"
                     :step="0.05"
                     :show-labels="false"
+                    @dblclick="synth.resetParam('envelopeDecay')"
                 />
                 <label class="block text-xs font-semibold mb-1 mt-3">
                     {{ (envelopeDecay * 10).toFixed(1) }}

--- a/src/components/modules/LFOModule.vue
+++ b/src/components/modules/LFOModule.vue
@@ -14,6 +14,7 @@
                 max="15"
                 step="0.1"
                 v-model.number="lfoFrequency"
+                @dblclick="synth.resetParam('lfoFrequency')"
                 class="w-full h-[8px] accent-black bg-black/10 rounded-full mb-3"
             />
             <p class="text-center text-xs text-gray-700">

--- a/src/components/modules/MasterOutput.vue
+++ b/src/components/modules/MasterOutput.vue
@@ -23,6 +23,7 @@
             step="0.01"
             v-model="volume"
             @input="updateVolume"
+            @dblclick="volume = DEFAULT_VOLUME; updateVolume()"
             class="w-full accent-green-500"
         />
 
@@ -75,7 +76,8 @@ masterGain.connect(analyser)
 analyser.connect(context.destination)
 
 // Volume state
-const volume = ref(0.8)
+const DEFAULT_VOLUME = 0.8
+const volume = ref(DEFAULT_VOLUME)
 const muted = ref(false)
 masterGain.gain.setValueAtTime(volume.value, context.currentTime)
 

--- a/src/components/modules/MixerModule.vue
+++ b/src/components/modules/MixerModule.vue
@@ -26,6 +26,7 @@
                     :max="1"
                     :step="0.05"
                     :show-labels="false"
+                    @dblclick="synth.resetParam('vcoLevel')"
                 />
                 <label class="block text-xs font-semibold mb-1 mt-3">
                     {{ (vcoLevel * 10).toFixed(1) }}
@@ -67,6 +68,7 @@
                     :max="1"
                     :step="0.05"
                     :show-labels="false"
+                    @dblclick="synth.resetParam('noiseLevel')"
                 />
                 <label class="block text-xs font-semibold mb-1 mt-3">
                     {{ (noiseLevel * 10).toFixed(1) }}

--- a/src/components/modules/VCAModule.vue
+++ b/src/components/modules/VCAModule.vue
@@ -33,6 +33,7 @@
                 :step="0.01"
                 :show-labels="false"
                 v-model.number="vcaMode"
+                @dblclick="synth.resetParam('vcaMode')"
                 class="mx-auto"
             />
 

--- a/src/components/modules/VCFModule.vue
+++ b/src/components/modules/VCFModule.vue
@@ -19,6 +19,7 @@
                     max="10000"
                     step="1"
                     v-model.number="filterCutoff"
+                    @dblclick="synth.resetParam('filterCutoff')"
                     class="w-full h-[8px] accent-black bg-black/10 rounded-full"
                 />
                 <p class="text-center text-xs mt-1 text-gray-700">
@@ -36,6 +37,7 @@
                     max="20"
                     step="0.1"
                     v-model.number="filterResonance"
+                    @dblclick="synth.resetParam('filterResonance')"
                     class="w-full h-[8px] accent-black bg-black/10 rounded-full"
                 />
                 <p class="text-center text-xs mt-1 text-gray-700">

--- a/src/components/modules/VCOModule.vue
+++ b/src/components/modules/VCOModule.vue
@@ -14,6 +14,7 @@
                 max="2000"
                 step="1"
                 v-model.number="vcoFrequency"
+                @dblclick="synth.resetParam('vcoFrequency')"
                 class="w-full h-[8px] accent-black bg-black/10 rounded-full mb-3"
             />
             <p class="text-center text-xs text-gray-700">

--- a/src/storage/synthStore.js
+++ b/src/storage/synthStore.js
@@ -2,6 +2,18 @@ import {defineStore} from 'pinia';
 import {ref} from 'vue';
 import {useSynthEngine} from '../composables/useSynthEngine';
 
+export const DEFAULTS = {
+    vcoFrequency: 440,
+    lfoFrequency: 5,
+    filterCutoff: 800,
+    filterResonance: 1,
+    envelopeAttack: 0.2,
+    envelopeDecay: 0.5,
+    vcoLevel: 1,
+    noiseLevel: 1,
+    vcaMode: 0,
+};
+
 export const useSynthStore = defineStore('synth', () => {
     const audioReady = ref(false);
     const engine = useSynthEngine();
@@ -347,6 +359,40 @@ export const useSynthStore = defineStore('synth', () => {
         envelopeDecay.value = val;
     };
 
+    const resetParam = key => {
+        const val = DEFAULTS[key];
+        if (val === undefined) return;
+        switch (key) {
+            case 'vcoFrequency':
+                setVcoFrequency(val);
+                break;
+            case 'lfoFrequency':
+                setLfoFrequency(val);
+                break;
+            case 'filterCutoff':
+                setFilterCutoff(val);
+                break;
+            case 'filterResonance':
+                setFilterResonance(val);
+                break;
+            case 'envelopeAttack':
+                setEnvelopeAttack(val);
+                break;
+            case 'envelopeDecay':
+                setEnvelopeDecay(val);
+                break;
+            case 'vcoLevel':
+                setMixerLevels(val, noiseLevel.value);
+                break;
+            case 'noiseLevel':
+                setMixerLevels(vcoLevel.value, val);
+                break;
+            case 'vcaMode':
+                setVcaMode(val);
+                break;
+        }
+    };
+
     // === Envelope Action ===
     const triggerVCAEnvelope = () => {
         ensureVCA();
@@ -440,6 +486,7 @@ export const useSynthStore = defineStore('synth', () => {
         setVcaMode,
         setEnvelopeAttack,
         setEnvelopeDecay,
+        resetParam,
         triggerEnvelope: triggerVCAEnvelope,
         getVCAOutputNode,
         getVCAInputNode,


### PR DESCRIPTION
## Summary
- emit dblclick events from `VerticalSlider`
- add a `resetParam` helper in the synth store
- use `resetParam` for double‑click resets across modules
- store master volume default locally

## Testing
- `yarn lint` *(fails: package not in lockfile)*
- `yarn test` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_687c9671f88c8326a5ce81dc985f2e16