### PR TITLE
refactor: centralize audio modules

### DIFF
--- a/src/storage/moduleStore.js
+++ b/src/storage/moduleStore.js
@@ -1,7 +1,13 @@
-import {defineStore} from 'pinia';
+import {defineStore, storeToRefs} from 'pinia';
+import {useSynthStore} from './synthStore';
+import {useSynthEngine} from '../composables/useSynthEngine';
 
+// Centralised store for managing WebAudio modules. This keeps all
+// AudioNode construction and lazy initialisation in one place so the
+// synth store can focus purely on parameter state.
 export const useModuleStore = defineStore('modules', () => {
-    let {
+    const synth = useSynthStore();
+    const {
         filterType,
         filterCutoff,
         filterResonance,
@@ -9,36 +15,51 @@ export const useModuleStore = defineStore('modules', () => {
         vcoWaveform,
         lfoFrequency,
         lfoWaveform,
-    } = refs;
+    } = storeToRefs(synth);
 
+    const engine = useSynthEngine();
+    const ctx = engine.context;
+
+    // === AudioNode references ===
     let vcoOsc, vcoOutGain;
     let lfoOsc, lfoOutGain;
     let noiseSrc, noiseOutGain;
-    let filterNode;
+    let filterInputGain, filterNode;
     let mixerNode;
     let vcaGainNode;
     let inverterGain;
     let triggerEnvelope;
+    let envelopeTriggerGain;
+    let triggerPollId;
+    let prevTrigger = 0;
+
+    // === Module Initialisers ===
 
     const initMixer = () => {
         mixerNode = ctx.createGain();
-        mixerNode.connect(filterNode);
+        if (filterInputGain) {
+            mixerNode.connect(filterInputGain);
+        }
     };
 
     const initVCF = () => {
+        filterInputGain = ctx.createGain();
         filterNode = engine.createFilterNode({
             type: filterType.value,
             frequency: filterCutoff.value,
             q: filterResonance.value,
         });
+        filterInputGain.connect(filterNode);
         mixerNode?.disconnect();
-        mixerNode?.connect(filterNode);
+        mixerNode?.connect(filterInputGain);
     };
 
     const initVCA = () => {
         const envelope = engine.createEnvelopeGain();
         vcaGainNode = envelope.gainNode;
         triggerEnvelope = envelope.triggerEnvelope;
+        ensureEnvelopeTrigger();
+
         filterNode?.connect(vcaGainNode);
         vcaGainNode.connect(ctx.destination);
     };
@@ -71,6 +92,7 @@ export const useModuleStore = defineStore('modules', () => {
         if (!result) return;
         lfoOsc = result.osc;
         lfoOutGain = result.gain;
+        ensureVCA();
         lfoOutGain.connect(vcaGainNode.gain);
     };
 
@@ -84,10 +106,24 @@ export const useModuleStore = defineStore('modules', () => {
         noiseOutGain.connect(mixerNode);
     };
 
-    // Lazy initializer helpers
+    const initEnvelopeTrigger = () => {
+        envelopeTriggerGain = ctx.createGain();
+        envelopeTriggerGain.gain.value = 0;
+        const poll = () => {
+            if (envelopeTriggerGain.gain.value > 0.5 && prevTrigger <= 0.5) {
+                triggerEnvelope?.();
+            }
+            prevTrigger = envelopeTriggerGain.gain.value;
+            triggerPollId = requestAnimationFrame(poll);
+        };
+        triggerPollId = requestAnimationFrame(poll);
+    };
+
+    // === Lazy Initialisers ===
+
     const ensureVCF = () => {
-        if (!filterNode) initVCF();
-        ensureMixer();
+        if (!filterNode || !filterInputGain) initVCF();
+        if (!mixerNode) initMixer();
     };
 
     const ensureVCA = () => {
@@ -118,14 +154,63 @@ export const useModuleStore = defineStore('modules', () => {
         if (!inverterGain) initInverter();
     };
 
+    const ensureEnvelopeTrigger = () => {
+        if (!envelopeTriggerGain) initEnvelopeTrigger();
+    };
+
+    const destroyAll = () => {
+        const safelyStopAndDisconnect = node => {
+            try {
+                node?.stop?.();
+            } catch (e) {
+                console.warn('Error stopping node:', e);
+            }
+            try {
+                node?.disconnect?.();
+            } catch (e) {
+                console.warn('Error disconnecting node:', e);
+            }
+        };
+
+        safelyStopAndDisconnect(vcoOsc);
+        safelyStopAndDisconnect(lfoOsc);
+        safelyStopAndDisconnect(noiseSrc);
+
+        [
+            vcoOutGain,
+            lfoOutGain,
+            noiseOutGain,
+            mixerNode,
+            filterInputGain,
+            filterNode,
+            vcaGainNode,
+            inverterGain,
+            envelopeTriggerGain,
+        ].forEach(n => {
+            try {
+                n?.disconnect();
+            } catch (e) {
+                console.warn('Error disconnecting node:', e);
+            }
+        });
+
+        if (triggerPollId) {
+            cancelAnimationFrame(triggerPollId);
+            triggerPollId = null;
+        }
+
+        vcoOsc = lfoOsc = noiseSrc = null;
+        vcoOutGain = lfoOutGain = noiseOutGain = null;
+        filterInputGain =
+            filterNode =
+            mixerNode =
+            vcaGainNode =
+            inverterGain =
+                null;
+        envelopeTriggerGain = triggerEnvelope = null;
+    };
+
     return {
-        initMixer,
-        initVCF,
-        initVCA,
-        initInverter,
-        initVCO,
-        initLFO,
-        initNoise,
         ensureVCF,
         ensureVCA,
         ensureVCO,
@@ -133,7 +218,7 @@ export const useModuleStore = defineStore('modules', () => {
         ensureNoise,
         ensureMixer,
         ensureInverter,
-        // Expose nodes if needed
+        ensureEnvelopeTrigger,
         getNodes: () => ({
             vcoOsc,
             vcoOutGain,
@@ -142,10 +227,13 @@ export const useModuleStore = defineStore('modules', () => {
             noiseSrc,
             noiseOutGain,
             filterNode,
+            filterInputGain,
             mixerNode,
             vcaGainNode,
             inverterGain,
+            envelopeTriggerGain,
             triggerEnvelope,
         }),
+        destroyAll,
     };
 });

--- a/src/storage/synthStore.js
+++ b/src/storage/synthStore.js
@@ -1,6 +1,7 @@
 import {defineStore} from 'pinia';
 import {ref} from 'vue';
 import {useSynthEngine} from '../composables/useSynthEngine';
+import {useModuleStore} from './moduleStore';
 
 export const DEFAULTS = {
     vcoFrequency: 440,
@@ -18,6 +19,7 @@ export const useSynthStore = defineStore('synth', () => {
     const audioReady = ref(false);
     const engine = useSynthEngine();
     const ctx = engine.context;
+    const modules = useModuleStore();
 
     // === Synth Parameter State ===
     const vcoFrequency = ref(440);
@@ -34,20 +36,6 @@ export const useSynthStore = defineStore('synth', () => {
     const vcaMode = ref(0);
     const masterOutputNode = ref(null);
 
-    // === AudioNode References ===
-    let vcoOsc, vcoOutGain;
-    let lfoOsc, lfoOutGain;
-    let noiseSrc, noiseOutGain;
-    let filterInputGain;
-    let filterNode;
-    let mixerNode;
-    let vcaGainNode;
-    let inverterGain;
-    let triggerEnvelope; // now from engine.createEnvelopeGain()
-    let envelopeTriggerGain;
-    let triggerPollId;
-    let prevTrigger = 0;
-
     async function resume() {
         await ctx.resume();
         if (ctx.state === 'running') {
@@ -55,30 +43,30 @@ export const useSynthStore = defineStore('synth', () => {
         }
     }
 
-    // === Modular Initializers ===
-
+    // === Module Node Accessors ===
     const getVCAOutputNode = () => {
-        ensureVCA();
-        return vcaGainNode;
+        modules.ensureVCA();
+        return modules.getNodes().vcaGainNode;
     };
 
     const getVCAInputNode = () => {
-        ensureVCA();
-        return vcaGainNode.gain;
+        modules.ensureVCA();
+        return modules.getNodes().vcaGainNode?.gain;
     };
 
     const getVCOOutputNode = () => {
-        ensureVCO();
-        return vcoOutGain;
+        modules.ensureVCO();
+        return modules.getNodes().vcoOutGain;
     };
 
     const getVCOInputNode = () => {
-        ensureVCO();
-        return vcoOsc?.frequency || null;
+        modules.ensureVCO();
+        return modules.getNodes().vcoOsc?.frequency || null;
     };
 
     const getVCFInputNode = index => {
-        ensureVCF();
+        modules.ensureVCF();
+        const {filterInputGain, filterNode} = modules.getNodes();
 
         if (index === 0) {
             return filterInputGain;
@@ -94,18 +82,18 @@ export const useSynthStore = defineStore('synth', () => {
     };
 
     const getVCFOutputNode = () => {
-        ensureVCF();
-        return filterNode;
+        modules.ensureVCF();
+        return modules.getNodes().filterNode;
     };
 
     const getNoiseOutputNode = () => {
-        ensureNoise();
-        return noiseOutGain;
+        modules.ensureNoise();
+        return modules.getNodes().noiseOutGain;
     };
 
     const getMixerOutputNode = () => {
-        ensureMixer();
-        return mixerNode;
+        modules.ensureMixer();
+        return modules.getNodes().mixerNode;
     };
 
     const setMasterOutputNode = node => {
@@ -115,185 +103,59 @@ export const useSynthStore = defineStore('synth', () => {
     const getMasterOutputNode = () => masterOutputNode.value;
 
     const getLFOOutputNode = () => {
-        ensureLFO();
-        return lfoOutGain;
+        modules.ensureLFO();
+        return modules.getNodes().lfoOutGain;
     };
 
     const getLFOInputNode = () => {
-        ensureLFO();
-        return lfoOsc?.frequency || null;
+        modules.ensureLFO();
+        return modules.getNodes().lfoOsc?.frequency || null;
     };
 
     const getInverterInputNode = () => {
-        ensureInverter();
-        return inverterGain;
+        modules.ensureInverter();
+        return modules.getNodes().inverterGain;
     };
 
     const getInverterOutputNode = () => {
-        ensureInverter();
-        return inverterGain;
-    };
-
-    const initMixer = () => {
-        mixerNode = ctx.createGain();
-        if (filterInputGain) {
-            mixerNode.connect(filterInputGain);
-        }
+        modules.ensureInverter();
+        return modules.getNodes().inverterGain;
     };
 
     const getEnvelopeTriggerInputNode = () => {
-        ensureEnvelopeTrigger();
-        return envelopeTriggerGain?.gain || null;
-    };
-
-    const initVCF = () => {
-        filterInputGain = ctx.createGain();
-        filterNode = engine.createFilterNode({
-            type: filterType.value,
-            frequency: filterCutoff.value,
-            q: filterResonance.value,
-        });
-
-        filterInputGain.connect(filterNode);
-        mixerNode?.disconnect();
-        mixerNode?.connect(filterInputGain);
-    };
-
-    const initVCA = () => {
-        const envelope = engine.createEnvelopeGain();
-        vcaGainNode = envelope.gainNode;
-        triggerEnvelope = envelope.triggerEnvelope;
-        ensureEnvelopeTrigger();
-
-        // Route filter → VCA → output
-        filterNode?.connect(vcaGainNode);
-        vcaGainNode.connect(ctx.destination);
-    };
-
-    // Create inverter (unused for now)
-    const initInverter = () => {
-        inverterGain = ctx.createGain();
-        inverterGain.gain.value = -1;
-    };
-
-    const initEnvelopeTrigger = () => {
-        envelopeTriggerGain = ctx.createGain();
-        envelopeTriggerGain.gain.value = 0;
-        const poll = () => {
-            if (envelopeTriggerGain.gain.value > 0.5 && prevTrigger <= 0.5) {
-                triggerVCAEnvelope();
-            }
-            prevTrigger = envelopeTriggerGain.gain.value;
-            triggerPollId = requestAnimationFrame(poll);
-        };
-        triggerPollId = requestAnimationFrame(poll);
-    };
-
-    const ensureEnvelopeTrigger = () => {
-        if (!envelopeTriggerGain) initEnvelopeTrigger();
-    };
-
-    const initVCO = () => {
-        const result = engine.createOscillatorNode({
-            frequency: vcoFrequency.value,
-            type: vcoWaveform.value,
-            gain: 1.0,
-        });
-        if (!result) return;
-        vcoOsc = result.osc;
-        vcoOutGain = result.gain;
-        ensureVCF();
-        ensureMixer();
-        vcoOutGain.connect(mixerNode);
-    };
-
-    const initLFO = () => {
-        const result = engine.createOscillatorNode({
-            frequency: lfoFrequency.value,
-            type: lfoWaveform.value,
-            gain: vcaMode.value,
-        });
-
-        if (!result) {
-            return;
-        }
-
-        lfoOsc = result.osc;
-        lfoOutGain = result.gain;
-        lfoOutGain.connect(vcaGainNode.gain); // ring mod
-    };
-
-    const initNoise = () => {
-        const result = engine.createNoiseNode();
-
-        if (!result) {
-            return;
-        }
-
-        noiseSrc = result.source;
-        noiseOutGain = result.gain;
-        ensureVCF();
-        ensureMixer();
-        noiseOutGain.connect(mixerNode);
-    };
-
-    const ensureVCF = () => {
-        if (!filterNode || !filterInputGain) initVCF();
-        if (!mixerNode) initMixer();
-    };
-
-    const ensureVCA = () => {
-        ensureVCF();
-        if (!vcaGainNode) initVCA();
-        ensureEnvelopeTrigger();
-    };
-
-    const ensureVCO = () => {
-        ensureVCA();
-        if (!vcoOsc) initVCO();
-    };
-
-    const ensureLFO = () => {
-        ensureVCA();
-        if (!lfoOsc) initLFO();
-    };
-
-    const ensureNoise = () => {
-        ensureVCF();
-        if (!noiseSrc) initNoise();
-    };
-
-    const ensureMixer = () => {
-        if (!mixerNode) initMixer();
-    };
-
-    const ensureInverter = () => {
-        if (!inverterGain) initInverter();
+        modules.ensureEnvelopeTrigger();
+        return modules.getNodes().envelopeTriggerGain?.gain || null;
     };
 
     // === Parameter Actions ===
 
     const setVcoFrequency = val => {
         vcoFrequency.value = val;
-        ensureVCO();
-        vcoOsc?.frequency.setValueAtTime(val, ctx.currentTime);
+        modules.ensureVCO();
+        modules
+            .getNodes()
+            .vcoOsc?.frequency.setValueAtTime(val, ctx.currentTime);
     };
 
     const setVcoWaveform = val => {
         vcoWaveform.value = val;
-        ensureVCO();
+        modules.ensureVCO();
+        const {vcoOsc} = modules.getNodes();
         if (vcoOsc) vcoOsc.type = val;
     };
 
     const setLfoFrequency = val => {
         lfoFrequency.value = val;
-        ensureLFO();
-        lfoOsc?.frequency.setValueAtTime(val, ctx.currentTime);
+        modules.ensureLFO();
+        modules
+            .getNodes()
+            .lfoOsc?.frequency.setValueAtTime(val, ctx.currentTime);
     };
 
     const setLfoWaveform = val => {
         lfoWaveform.value = val;
-        ensureLFO();
+        modules.ensureLFO();
+        const {lfoOsc} = modules.getNodes();
         if (lfoOsc) lfoOsc.type = val;
     };
 
@@ -303,12 +165,11 @@ export const useSynthStore = defineStore('synth', () => {
     const FILTER_SMOOTH_TIME = 0.02;
 
     const setFilterCutoff = val => {
-        filterCutoff.value = val;
         const clamped = Math.max(FILTER_MIN_FREQ, val);
         filterCutoff.value = clamped;
-        ensureVCF();
+        modules.ensureVCF();
+        const {filterNode} = modules.getNodes();
         filterNode?.frequency.setValueAtTime(val, ctx.currentTime);
-
         if (!filterNode) {
             return;
         }
@@ -319,12 +180,11 @@ export const useSynthStore = defineStore('synth', () => {
     };
 
     const setFilterResonance = val => {
-        filterResonance.value = val;
         const clamped = Math.min(FILTER_MAX_Q, Math.max(FILTER_MIN_Q, val));
         filterResonance.value = clamped;
-        ensureVCF();
+        modules.ensureVCF();
+        const {filterNode} = modules.getNodes();
         filterNode?.Q.setValueAtTime(val, ctx.currentTime);
-
         if (!filterNode) {
             return;
         }
@@ -336,8 +196,8 @@ export const useSynthStore = defineStore('synth', () => {
 
     const setFilterType = val => {
         filterType.value = val;
-        ensureVCF();
-
+        modules.ensureVCF();
+        const {filterNode} = modules.getNodes();
         if (filterNode) {
             filterNode.type = val;
         }
@@ -346,16 +206,19 @@ export const useSynthStore = defineStore('synth', () => {
     const setMixerLevels = (vcoLvl, noiseLvl) => {
         vcoLevel.value = vcoLvl;
         noiseLevel.value = noiseLvl;
-        ensureVCO();
-        ensureNoise();
-        vcoOutGain?.gain.setValueAtTime(vcoLvl, ctx.currentTime);
-        noiseOutGain?.gain.setValueAtTime(noiseLvl, ctx.currentTime);
+        modules.ensureVCO();
+        modules.ensureNoise();
+        const nodes = modules.getNodes();
+        nodes.vcoOutGain?.gain.setValueAtTime(vcoLvl, ctx.currentTime);
+        nodes.noiseOutGain?.gain.setValueAtTime(noiseLvl, ctx.currentTime);
     };
 
     const setVcaMode = mode => {
         vcaMode.value = mode;
-        ensureLFO();
-        lfoOutGain?.gain.setValueAtTime(mode, ctx.currentTime);
+        modules.ensureLFO();
+        modules
+            .getNodes()
+            .lfoOutGain?.gain.setValueAtTime(mode, ctx.currentTime);
     };
 
     const setEnvelopeAttack = val => {
@@ -402,8 +265,9 @@ export const useSynthStore = defineStore('synth', () => {
 
     // === Envelope Action ===
     const triggerVCAEnvelope = () => {
-        ensureVCA();
-        if (!triggerEnvelope || !vcaGainNode) return;
+        modules.ensureVCA();
+        const {triggerEnvelope} = modules.getNodes();
+        if (!triggerEnvelope) return;
 
         const peak = 1 - vcaMode.value;
         triggerEnvelope({
@@ -414,55 +278,7 @@ export const useSynthStore = defineStore('synth', () => {
     };
 
     const destroySynth = () => {
-        const safelyStopAndDisconnect = node => {
-            try {
-                node?.stop?.();
-            } catch (e) {
-                console.warn('Error stopping node:', e);
-            }
-            try {
-                node?.disconnect?.();
-            } catch (e) {
-                console.warn('Error disconnecting node:', e);
-            }
-        };
-
-        safelyStopAndDisconnect(vcoOsc);
-        safelyStopAndDisconnect(lfoOsc);
-        safelyStopAndDisconnect(noiseSrc);
-
-        [
-            vcoOutGain,
-            lfoOutGain,
-            noiseOutGain,
-            mixerNode,
-            filterInputGain,
-            filterNode,
-            vcaGainNode,
-            inverterGain,
-        ].forEach(n => {
-            try {
-                n?.disconnect();
-            } catch (e) {
-                console.warn('Error disconnecting node:', e);
-            }
-        });
-
-        if (triggerPollId) {
-            cancelAnimationFrame(triggerPollId);
-            triggerPollId = null;
-        }
-
-        envelopeTriggerGain = null;
-        vcoOsc = lfoOsc = noiseSrc = null;
-        vcoOutGain = lfoOutGain = noiseOutGain = null;
-        filterInputGain =
-            filterNode =
-            mixerNode =
-            vcaGainNode =
-            inverterGain =
-            triggerEnvelope =
-                null;
+        modules.destroyAll();
     };
 
     return {


### PR DESCRIPTION
## Summary
- replace undefined refs in moduleStore with reactive synth store references
- centralize WebAudio node initialization and lifecycle management
- delegate synthStore module accessors to moduleStore for easier maintenance

## Testing
- `npm test` *(fails: No test files found)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688f103833d88326b97d6c7e1f58d5f3