### PR TITLE
test: add patch and module store suites

### DIFF
--- a/tests/ModuleStore.test.js
+++ b/tests/ModuleStore.test.js
@@ -1,0 +1,102 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { setActivePinia, createPinia } from 'pinia';
+import { ref } from 'vue';
+
+globalThis.requestAnimationFrame = vi.fn(() => 1);
+globalThis.cancelAnimationFrame = vi.fn();
+
+const createMockNode = () => ({
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+    stop: vi.fn(),
+    gain: { value: 1, connect: vi.fn(), disconnect: vi.fn() },
+});
+
+const ctx = {
+    createGain: vi.fn(() => createMockNode()),
+    destination: createMockNode(),
+    currentTime: 0,
+};
+
+const engine = {
+    context: ctx,
+    createFilterNode: vi.fn(() => ({
+        connect: vi.fn(),
+        disconnect: vi.fn(),
+        frequency: {},
+        Q: {},
+    })),
+    createOscillatorNode: vi.fn(() => ({
+        osc: createMockNode(),
+        gain: createMockNode(),
+    })),
+    createNoiseNode: vi.fn(() => ({
+        source: createMockNode(),
+        gain: createMockNode(),
+    })),
+    createEnvelopeGain: vi.fn(() => ({
+        gainNode: createMockNode(),
+        triggerEnvelope: vi.fn(),
+    })),
+};
+
+vi.mock('../src/composables/useSynthEngine.js', () => ({
+    useSynthEngine: () => engine,
+}));
+
+vi.mock('../src/storage/synthStore.js', () => ({
+    useSynthStore: () => ({
+        filterType: ref('lowpass'),
+        filterCutoff: ref(800),
+        filterResonance: ref(1),
+        vcoFrequency: ref(440),
+        vcoWaveform: ref('sawtooth'),
+        lfoFrequency: ref(5),
+        lfoWaveform: ref('sine'),
+    }),
+}));
+
+import { useModuleStore } from '../src/storage/moduleStore.js';
+
+describe('moduleStore', () => {
+    let modules;
+
+    beforeEach(() => {
+        setActivePinia(createPinia());
+        modules = useModuleStore();
+        vi.clearAllMocks();
+    });
+
+    it('creates nodes lazily', () => {
+        modules.ensureVCO();
+        modules.ensureVCO();
+
+        expect(engine.createOscillatorNode).toHaveBeenCalledTimes(1);
+        expect(engine.createEnvelopeGain).toHaveBeenCalledTimes(1);
+        expect(engine.createFilterNode).toHaveBeenCalledTimes(1);
+    });
+
+    it('destroys nodes and allows reinitialisation', () => {
+        modules.ensureVCO();
+        modules.ensureLFO();
+        const nodes = modules.getNodes();
+
+        modules.destroyAll();
+
+        expect(nodes.vcoOsc.stop).toHaveBeenCalled();
+        expect(nodes.vcoOsc.disconnect).toHaveBeenCalled();
+        expect(nodes.lfoOsc.stop).toHaveBeenCalled();
+        expect(nodes.lfoOsc.disconnect).toHaveBeenCalled();
+        expect(nodes.vcoOutGain.disconnect).toHaveBeenCalled();
+        expect(nodes.lfoOutGain.disconnect).toHaveBeenCalled();
+        expect(globalThis.cancelAnimationFrame).toHaveBeenCalled();
+        const cleared = modules.getNodes();
+        expect(cleared.vcoOsc).toBeNull();
+        expect(cleared.lfoOsc).toBeNull();
+
+        engine.createOscillatorNode.mockClear();
+        modules.ensureVCO();
+        expect(engine.createOscillatorNode).toHaveBeenCalledTimes(1);
+    });
+});
+

--- a/tests/PatchStore.test.js
+++ b/tests/PatchStore.test.js
@@ -6,8 +6,8 @@ import { useModuleRegistry } from '../src/composables/useModuleRegistry.js';
 globalThis.AudioParam = class {};
 
 const createModule = id => {
-    const outputs = [ { connect: vi.fn(), disconnect: vi.fn() } ];
-    const inputs = [ { connect: vi.fn(), disconnect: vi.fn() } ];
+    const outputs = [{ connect: vi.fn(), disconnect: vi.fn() }];
+    const inputs = [{ connect: vi.fn(), disconnect: vi.fn() }];
     return {
         id,
         getOutputNode: vi.fn(index => outputs[index]),
@@ -17,7 +17,7 @@ const createModule = id => {
     };
 };
 
-describe('removeConnectionsForModule', () => {
+describe('patchStore', () => {
     let patchStore;
     let registry;
     let mod1, mod2, mod3;
@@ -32,26 +32,61 @@ describe('removeConnectionsForModule', () => {
         registry.register('1', mod1);
         registry.register('2', mod2);
         registry.register('3', mod3);
-        patchStore.connectNodes(mod1, 0, mod2, 0);
-        patchStore.connectNodes(mod2, 0, mod3, 0);
-        patchStore.connectNodes(mod1, 0, mod3, 0);
     });
 
-    it('disconnects and removes patches for a specific module', () => {
-        patchStore.removeConnectionsForModule('2');
+    describe('connectNodes and disconnectNodes', () => {
+        it('connects and disconnects modules', () => {
+            const connected = patchStore.connectNodes(mod1, 0, mod2, 0);
+            expect(connected).toBe(true);
+            expect(mod1.outputs[0].connect).toHaveBeenCalledWith(mod2.inputs[0]);
+            expect(patchStore.patches.length).toBe(1);
 
-        expect(patchStore.patches.length).toBe(1);
-        const remaining = patchStore.patches[0];
-        expect(remaining.from.id).toBe('1');
-        expect(remaining.to.id).toBe('3');
-        expect(mod1.outputs[0].disconnect).toHaveBeenCalledWith(mod2.inputs[0]);
-        expect(mod2.outputs[0].disconnect).toHaveBeenCalledWith(mod3.inputs[0]);
-        expect(mod1.outputs[0].disconnect).toHaveBeenCalledTimes(1);
-        expect(mod1.outputs[0].disconnect).not.toHaveBeenCalledWith(mod3.inputs[0]);
+            const disconnected = patchStore.disconnectNodes(mod1, 0, mod2, 0);
+            expect(disconnected).toBe(true);
+            expect(mod1.outputs[0].disconnect).toHaveBeenCalledWith(mod2.inputs[0]);
+            expect(patchStore.patches.length).toBe(0);
+        });
+    });
 
-        // ensure active connection can be re-established
-        patchStore.connectNodes(mod1, 0, mod2, 0);
-        expect(patchStore.patches.length).toBe(2);
-        expect(mod1.outputs[0].connect).toHaveBeenCalledTimes(3);
+    describe('undo and redo', () => {
+        it('reverses and reapplies patch actions', () => {
+            patchStore.connectNodes(mod1, 0, mod2, 0);
+            patchStore.disconnectNodes(mod1, 0, mod2, 0);
+            expect(patchStore.patches.length).toBe(0);
+
+            patchStore.undo();
+            expect(patchStore.patches.length).toBe(1);
+            expect(mod1.outputs[0].connect).toHaveBeenCalledTimes(2);
+
+            patchStore.redo();
+            expect(patchStore.patches.length).toBe(0);
+            expect(mod1.outputs[0].disconnect).toHaveBeenCalledTimes(2);
+        });
+    });
+
+    describe('removeConnectionsForModule', () => {
+        beforeEach(() => {
+            patchStore.connectNodes(mod1, 0, mod2, 0);
+            patchStore.connectNodes(mod2, 0, mod3, 0);
+            patchStore.connectNodes(mod1, 0, mod3, 0);
+        });
+
+        it('disconnects and removes patches for a specific module', () => {
+            patchStore.removeConnectionsForModule('2');
+
+            expect(patchStore.patches.length).toBe(1);
+            const remaining = patchStore.patches[0];
+            expect(remaining.from.id).toBe('1');
+            expect(remaining.to.id).toBe('3');
+            expect(mod1.outputs[0].disconnect).toHaveBeenCalledWith(mod2.inputs[0]);
+            expect(mod2.outputs[0].disconnect).toHaveBeenCalledWith(mod3.inputs[0]);
+            expect(mod1.outputs[0].disconnect).toHaveBeenCalledTimes(1);
+            expect(mod1.outputs[0].disconnect).not.toHaveBeenCalledWith(mod3.inputs[0]);
+
+            patchStore.connectNodes(mod1, 0, mod2, 0);
+            expect(patchStore.patches.length).toBe(2);
+            expect(mod1.outputs[0].connect).toHaveBeenCalledTimes(3);
+        });
     });
 });
+


### PR DESCRIPTION
## Summary
- add vitest coverage for patchStore connection logic, undo/redo and removeConnectionsForModule
- test moduleStore lazy node creation and cleanup

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688f555d5ac48326bd173561fede5cd0