### PR TITLE
refactor-audio-context-when-destroyed

### DIFF
--- a/src/audio/audioEngine.js
+++ b/src/audio/audioEngine.js
@@ -1,0 +1,247 @@
+import {useSynthEngine} from '@/composables/useSynthEngine';
+
+export class AudioEngine {
+    constructor(
+        {
+            vcoFrequency = 440,
+            vcoWaveform = 'sawtooth',
+            lfoFrequency = 5,
+            lfoWaveform = 'sine',
+            filterCutoff = 800,
+            filterResonance = 1,
+            filterType = 'lowpass',
+        } = {},
+        engine = useSynthEngine()
+    ) {
+        this.engine = engine;
+        this.ctx = engine.context;
+        this.context = this.ctx;
+
+        this.vcoFrequency = vcoFrequency;
+        this.vcoWaveform = vcoWaveform;
+        this.lfoFrequency = lfoFrequency;
+        this.lfoWaveform = lfoWaveform;
+        this.filterCutoff = filterCutoff;
+        this.filterResonance = filterResonance;
+        this.filterType = filterType;
+
+        // Node references
+        this.vcoOsc = null;
+        this.vcoOutGain = null;
+        this.lfoOsc = null;
+        this.lfoOutGain = null;
+        this.noiseSrc = null;
+        this.noiseOutGain = null;
+        this.filterInputGain = null;
+        this.filterNode = null;
+        this.mixerNode = null;
+        this.vcaGainNode = null;
+        this.inverterGain = null;
+        this.triggerEnvelope = null;
+        this.envelopeTriggerGain = null;
+        this.triggerPollId = null;
+        this.prevTrigger = 0;
+    }
+
+    async resume() {
+        return this.engine.resume ? this.engine.resume() : Promise.resolve();
+    }
+
+    // === Node initialisers ===
+    initMixer() {
+        this.mixerNode = this.ctx.createGain();
+        if (this.filterInputGain) {
+            this.mixerNode.connect(this.filterInputGain);
+        }
+    }
+
+    initVCF() {
+        this.filterInputGain = this.ctx.createGain();
+        this.filterNode = this.engine.createFilterNode({
+            type: this.filterType,
+            frequency: this.filterCutoff,
+            q: this.filterResonance,
+        });
+        this.filterInputGain.connect(this.filterNode);
+        this.mixerNode?.disconnect();
+        this.mixerNode?.connect(this.filterInputGain);
+    }
+
+    initVCA() {
+        const envelope = this.engine.createEnvelopeGain();
+        this.vcaGainNode = envelope.gainNode;
+        this.triggerEnvelope = envelope.triggerEnvelope;
+        this.ensureEnvelopeTrigger();
+
+        this.filterNode?.connect(this.vcaGainNode);
+        this.vcaGainNode.connect(this.ctx.destination);
+    }
+
+    initInverter() {
+        this.inverterGain = this.ctx.createGain();
+        this.inverterGain.gain.value = -1;
+    }
+
+    initVCO() {
+        const result = this.engine.createOscillatorNode({
+            frequency: this.vcoFrequency,
+            type: this.vcoWaveform,
+            gain: 1.0,
+        });
+        if (!result) return;
+        this.vcoOsc = result.osc;
+        this.vcoOutGain = result.gain;
+        this.ensureVCF();
+        this.ensureMixer();
+        this.vcoOutGain.connect(this.mixerNode);
+    }
+
+    initLFO() {
+        const result = this.engine.createOscillatorNode({
+            frequency: this.lfoFrequency,
+            type: this.lfoWaveform,
+            gain: 1.0,
+        });
+        if (!result) return;
+        this.lfoOsc = result.osc;
+        this.lfoOutGain = result.gain;
+        this.ensureVCA();
+        this.lfoOutGain.connect(this.vcaGainNode.gain);
+    }
+
+    initNoise() {
+        const result = this.engine.createNoiseNode();
+        if (!result) return;
+        this.noiseSrc = result.source;
+        this.noiseOutGain = result.gain;
+        this.ensureVCF();
+        this.ensureMixer();
+        this.noiseOutGain.connect(this.mixerNode);
+    }
+
+    initEnvelopeTrigger() {
+        this.envelopeTriggerGain = this.ctx.createGain();
+        this.envelopeTriggerGain.gain.value = 0;
+        const poll = () => {
+            if (
+                this.envelopeTriggerGain.gain.value > 0.5 &&
+                this.prevTrigger <= 0.5
+            ) {
+                this.triggerEnvelope?.();
+            }
+            this.prevTrigger = this.envelopeTriggerGain.gain.value;
+            this.triggerPollId = requestAnimationFrame(poll);
+        };
+        this.triggerPollId = requestAnimationFrame(poll);
+    }
+
+    // === Lazy initialisers ===
+    ensureVCF() {
+        if (!this.filterNode || !this.filterInputGain) this.initVCF();
+        if (!this.mixerNode) this.initMixer();
+    }
+
+    ensureVCA() {
+        this.ensureVCF();
+        if (!this.vcaGainNode) this.initVCA();
+    }
+
+    ensureVCO() {
+        this.ensureVCA();
+        if (!this.vcoOsc) this.initVCO();
+    }
+
+    ensureLFO() {
+        this.ensureVCA();
+        if (!this.lfoOsc) this.initLFO();
+    }
+
+    ensureNoise() {
+        this.ensureVCF();
+        if (!this.noiseSrc) this.initNoise();
+    }
+
+    ensureMixer() {
+        if (!this.mixerNode) this.initMixer();
+    }
+
+    ensureInverter() {
+        if (!this.inverterGain) this.initInverter();
+    }
+
+    ensureEnvelopeTrigger() {
+        if (!this.envelopeTriggerGain) this.initEnvelopeTrigger();
+    }
+
+    getNodes() {
+        return {
+            vcoOsc: this.vcoOsc,
+            vcoOutGain: this.vcoOutGain,
+            lfoOsc: this.lfoOsc,
+            lfoOutGain: this.lfoOutGain,
+            noiseSrc: this.noiseSrc,
+            noiseOutGain: this.noiseOutGain,
+            filterNode: this.filterNode,
+            filterInputGain: this.filterInputGain,
+            mixerNode: this.mixerNode,
+            vcaGainNode: this.vcaGainNode,
+            inverterGain: this.inverterGain,
+            envelopeTriggerGain: this.envelopeTriggerGain,
+            triggerEnvelope: this.triggerEnvelope,
+        };
+    }
+
+    destroyAll() {
+        const safelyStopAndDisconnect = node => {
+            try {
+                node?.stop?.();
+            } catch (e) {
+                console.warn('Error stopping node:', e);
+            }
+            try {
+                node?.disconnect?.();
+            } catch (e) {
+                console.warn('Error disconnecting node:', e);
+            }
+        };
+
+        safelyStopAndDisconnect(this.vcoOsc);
+        safelyStopAndDisconnect(this.lfoOsc);
+        safelyStopAndDisconnect(this.noiseSrc);
+
+        [
+            this.vcoOutGain,
+            this.lfoOutGain,
+            this.noiseOutGain,
+            this.mixerNode,
+            this.filterInputGain,
+            this.filterNode,
+            this.vcaGainNode,
+            this.inverterGain,
+            this.envelopeTriggerGain,
+        ].forEach(n => {
+            try {
+                n?.disconnect();
+            } catch (e) {
+                console.warn('Error disconnecting node:', e);
+            }
+        });
+
+        if (this.triggerPollId) {
+            cancelAnimationFrame(this.triggerPollId);
+            this.triggerPollId = null;
+        }
+
+        this.vcoOsc = this.lfoOsc = this.noiseSrc = null;
+        this.vcoOutGain = this.lfoOutGain = this.noiseOutGain = null;
+        this.filterInputGain =
+            this.filterNode =
+            this.mixerNode =
+            this.vcaGainNode =
+            this.inverterGain =
+                null;
+        this.envelopeTriggerGain = this.triggerEnvelope = null;
+    }
+}
+
+export default AudioEngine;

--- a/src/components/VerticalSlider.vue
+++ b/src/components/VerticalSlider.vue
@@ -46,7 +46,7 @@ const props = defineProps({
     },
 });
 
-const emit = defineEmits(['update:modelValue', 'dblclick']);
+defineEmits(['update:modelValue', 'dblclick']);
 const value = ref(props.modelValue);
 
 watch(

--- a/src/components/modules/EnvelopeGenerator.vue
+++ b/src/components/modules/EnvelopeGenerator.vue
@@ -104,9 +104,10 @@
 </template>
 
 <script setup>
-import {computed, onMounted, onUnmounted, ref} from 'vue';
+import {computed, ref} from 'vue';
 import {useModuleConnections} from '@/composables/useModuleConnections';
 import {useSynthStore} from '@/storage/synthStore';
+import {useAnimationSchedule} from '@/composables/useAnimationSchedule';
 import SynthPanel from '@/components/SynthPanel.vue';
 import VerticalSlider from '@/components/VerticalSlider.vue';
 import JackPanel from '@/components/JackPanel.vue';
@@ -114,29 +115,15 @@ import BaseButton from '@/components/base/BaseButton.vue';
 
 const synth = useSynthStore();
 const id = 'envelope-generator';
-
 const level = ref(0);
-let rafId;
-
 const envelopeActive = computed(() => level.value > 0.01);
-
 const getInputNode = index => synth.getEnvelopeTriggerInputNode?.(index);
 
 const {connectedInputs, handlePatch} = useModuleConnections(id, {getInputNode});
 
-onMounted(() => {
-    const update = () => {
-        const gain = synth.getVCAInputNode?.();
-        level.value = gain ? gain.value : 0;
-        rafId = requestAnimationFrame(update);
-    };
-    update();
-});
-
-onUnmounted(() => {
-    if (rafId) {
-        cancelAnimationFrame(rafId);
-    }
+useAnimationSchedule(() => {
+    const gain = synth.getVCAInputNode?.();
+    level.value = gain ? gain.value : 0;
 });
 
 const envelopeAttack = computed({

--- a/src/components/modules/LFOModule.vue
+++ b/src/components/modules/LFOModule.vue
@@ -68,6 +68,7 @@ import {computed, onMounted, onUnmounted, ref} from 'vue';
 import {useSynthStore} from '@/storage/synthStore';
 import {useModuleConnections} from '@/composables/useModuleConnections';
 import {useSynthEngine} from '@/composables/useSynthEngine';
+import {useAnimationSchedule} from '@/composables/useAnimationSchedule';
 import SynthPanel from '@/components/SynthPanel.vue';
 import JackPanel from '@/components/JackPanel.vue';
 import RadioButtonGroup from '@/components/base/RadioButtonGroup.vue';
@@ -78,7 +79,7 @@ const engine = useSynthEngine();
 const context = engine.context;
 
 const level = ref(0);
-let analyser, buffer, rafId;
+let analyser, buffer, stop;
 
 const lfoHigh = computed(() => level.value > 0);
 
@@ -103,17 +104,14 @@ onMounted(() => {
         const update = () => {
             analyser.getByteTimeDomainData(buffer);
             level.value = (buffer[0] - 128) / 128;
-            rafId = requestAnimationFrame(update);
         };
-        update();
+        stop = useAnimationSchedule(update);
     }
 });
 
 onUnmounted(() => {
-    if (rafId) {
-        cancelAnimationFrame(rafId);
-        analyser?.disconnect();
-    }
+    stop?.();
+    analyser?.disconnect();
 });
 
 const lfoFrequency = computed({

--- a/src/components/modules/MasterOutput.vue
+++ b/src/components/modules/MasterOutput.vue
@@ -135,6 +135,7 @@ import {useSynthEngine} from '@/composables/useSynthEngine';
 import {useModuleConnections} from '@/composables/useModuleConnections';
 import {useModuleLifecycle} from '@/composables/useModuleLifecycle';
 import {useSynthStore} from '@/storage/synthStore';
+import {useAnimationSchedule} from '@/composables/useAnimationSchedule';
 import SynthPanel from '@/components/SynthPanel.vue';
 import JackPanel from '@/components/JackPanel.vue';
 import VerticalSlider from '@/components/VerticalSlider.vue';
@@ -144,6 +145,7 @@ const engine = useSynthEngine();
 const synth = useSynthStore();
 const id = 'master-output';
 const context = engine.context;
+const scheduler = useAnimationSchedule();
 
 // Nodes
 const inputGain = context.createGain();

--- a/src/components/modules/Oscilloscope.vue
+++ b/src/components/modules/Oscilloscope.vue
@@ -35,6 +35,7 @@ import {ref, onMounted, onUnmounted, watch} from 'vue';
 import {useSynthEngine} from '@/composables/useSynthEngine';
 import {useModuleLifecycle} from '@/composables/useModuleLifecycle';
 import {useSynthStore} from '@/storage/synthStore';
+import {useAnimationSchedule} from '@/composables/useAnimationSchedule';
 import SynthPanel from '@/components/SynthPanel.vue';
 import BaseButton from '@/components/base/BaseButton.vue';
 
@@ -51,7 +52,7 @@ useModuleLifecycle(analyser);
 const scopeContainer = ref(null);
 const scopeCanvas = ref(null);
 let ctx = null;
-let animationFrame = null;
+let stopRender;
 let bufferLength = analyser.fftSize;
 let dataArray = new Uint8Array(bufferLength);
 const masterGain = ref(null);
@@ -133,7 +134,6 @@ const drawCurve = points => {
 
 // Render loop
 const render = time => {
-    animationFrame = requestAnimationFrame(render);
     const delta = time - lastFrameTime;
     if (delta < frameInterval) {
         return;
@@ -188,13 +188,11 @@ onMounted(() => {
     resizeCanvas();
     window.addEventListener('resize', resizeCanvas);
 
-    animationFrame = requestAnimationFrame(render);
+    stopRender = useAnimationSchedule(render);
 });
 
 onUnmounted(() => {
-    if (animationFrame) {
-        cancelAnimationFrame(animationFrame);
-    }
+    stopRender?.();
 
     window.removeEventListener('resize', resizeCanvas);
     analyser.disconnect();

--- a/src/components/modules/VCAModule.vue
+++ b/src/components/modules/VCAModule.vue
@@ -17,7 +17,9 @@
                     @patch="handlePatch"
                 />
             </section>
-            <h3 class="text-center text-wrap text-xl font-medium mb-8 uppercase">
+            <h3
+                class="text-center text-wrap text-xl font-medium mb-8 uppercase"
+            >
                 VCA
             </h3>
         </template>

--- a/src/composables/useAnimationSchedule.js
+++ b/src/composables/useAnimationSchedule.js
@@ -1,0 +1,42 @@
+import {onUnmounted} from 'vue';
+
+const subscribers = new Set();
+let rafId = null;
+
+const tick = time => {
+    subscribers.forEach(cb => {
+        try {
+            cb(time);
+        } catch (e) {
+            console.warn('Animation callback failed:', e);
+        }
+    });
+    if (subscribers.size > 0) {
+        rafId = requestAnimationFrame(tick);
+    } else {
+        rafId = null;
+    }
+};
+
+const subscribe = cb => {
+    subscribers.add(cb);
+    if (rafId === null) {
+        rafId = requestAnimationFrame(tick);
+    }
+    return () => {
+        subscribers.delete(cb);
+        if (subscribers.size === 0 && rafId !== null) {
+            cancelAnimationFrame(rafId);
+            rafId = null;
+        }
+    };
+};
+
+export const useAnimationSchedule = callback => {
+    if (callback) {
+        const unsubscribe = subscribe(callback);
+        onUnmounted(() => unsubscribe());
+        return unsubscribe;
+    }
+    return {subscribe};
+};

--- a/src/composables/useSynthEngine.js
+++ b/src/composables/useSynthEngine.js
@@ -1,5 +1,9 @@
 let defaultAudioContext = null;
 
+export const resetDefaultAudioContext = () => {
+    defaultAudioContext = null;
+};
+
 export const useSynthEngine = (injectedContext = null) => {
     const getContext = () => {
         if (injectedContext) {

--- a/src/storage/moduleStore.js
+++ b/src/storage/moduleStore.js
@@ -1,6 +1,7 @@
 import {defineStore, storeToRefs} from 'pinia';
 import {useSynthStore} from './synthStore';
-import {useSynthEngine} from '../composables/useSynthEngine';
+import {useSynthEngine} from '@/composables/useSynthEngine';
+import {useAnimationSchedule} from '@/composables/useAnimationSchedule';
 
 export const useModuleStore = defineStore('modules', () => {
     const synth = useSynthStore();
@@ -27,7 +28,7 @@ export const useModuleStore = defineStore('modules', () => {
     let inverterGain;
     let triggerEnvelope;
     let envelopeTriggerGain;
-    let triggerPollId;
+    let stopTriggerPoll;
     let prevTrigger = 0;
 
     const initMixer = () => {
@@ -101,6 +102,8 @@ export const useModuleStore = defineStore('modules', () => {
         noiseOutGain.connect(mixerNode);
     };
 
+    const scheduler = useAnimationSchedule();
+
     const initEnvelopeTrigger = () => {
         envelopeTriggerGain = ctx.createGain();
         envelopeTriggerGain.gain.value = 0;
@@ -109,12 +112,11 @@ export const useModuleStore = defineStore('modules', () => {
                 triggerEnvelope?.();
             }
             prevTrigger = envelopeTriggerGain.gain.value;
-            triggerPollId = requestAnimationFrame(poll);
         };
-        triggerPollId = requestAnimationFrame(poll);
+        stopTriggerPoll = scheduler.subscribe(poll);
     };
 
-    // === Lazy Initialisers ===
+    // === Lazy Initialise ===
 
     const ensureVCF = () => {
         if (!filterNode || !filterInputGain) initVCF();
@@ -189,10 +191,8 @@ export const useModuleStore = defineStore('modules', () => {
             }
         });
 
-        if (triggerPollId) {
-            cancelAnimationFrame(triggerPollId);
-            triggerPollId = null;
-        }
+        stopTriggerPoll?.();
+        stopTriggerPoll = null;
 
         vcoOsc = lfoOsc = noiseSrc = null;
         vcoOutGain = lfoOutGain = noiseOutGain = null;

--- a/src/storage/synthStore.js
+++ b/src/storage/synthStore.js
@@ -1,7 +1,7 @@
 import {defineStore} from 'pinia';
 import {ref} from 'vue';
-import {useSynthEngine} from '../composables/useSynthEngine';
-import {useModuleStore} from './moduleStore';
+import {resetDefaultAudioContext} from '@/composables/useSynthEngine';
+import {AudioEngine} from '@/audio/AudioEngine';
 
 export const DEFAULTS = {
     vcoFrequency: 440,
@@ -17,9 +17,8 @@ export const DEFAULTS = {
 
 export const useSynthStore = defineStore('synth', () => {
     const audioReady = ref(false);
-    const engine = useSynthEngine();
-    const ctx = engine.context;
-    const modules = useModuleStore();
+    const audioEngine = new AudioEngine();
+    const ctx = audioEngine.context;
 
     // === Synth Parameter State ===
     const vcoFrequency = ref(440);
@@ -37,7 +36,7 @@ export const useSynthStore = defineStore('synth', () => {
     const masterOutputNode = ref(null);
 
     async function resume() {
-        await ctx.resume();
+        await audioEngine.resume();
         if (ctx.state === 'running') {
             audioReady.value = true;
         }
@@ -45,28 +44,28 @@ export const useSynthStore = defineStore('synth', () => {
 
     // === Module Node Accessors ===
     const getVCAOutputNode = () => {
-        modules.ensureVCA();
-        return modules.getNodes().vcaGainNode;
+        audioEngine.ensureVCA();
+        return audioEngine.getNodes().vcaGainNode;
     };
 
     const getVCAInputNode = () => {
-        modules.ensureVCA();
-        return modules.getNodes().vcaGainNode?.gain;
+        audioEngine.ensureVCA();
+        return audioEngine.getNodes().vcaGainNode?.gain;
     };
 
     const getVCOOutputNode = () => {
-        modules.ensureVCO();
-        return modules.getNodes().vcoOutGain;
+        audioEngine.ensureVCO();
+        return audioEngine.getNodes().vcoOutGain;
     };
 
     const getVCOInputNode = () => {
-        modules.ensureVCO();
-        return modules.getNodes().vcoOsc?.frequency || null;
+        audioEngine.ensureVCO();
+        return audioEngine.getNodes().vcoOsc?.frequency || null;
     };
 
     const getVCFInputNode = index => {
-        modules.ensureVCF();
-        const {filterInputGain, filterNode} = modules.getNodes();
+        audioEngine.ensureVCF();
+        const {filterInputGain, filterNode} = audioEngine.getNodes();
 
         if (index === 0) {
             return filterInputGain;
@@ -82,18 +81,18 @@ export const useSynthStore = defineStore('synth', () => {
     };
 
     const getVCFOutputNode = () => {
-        modules.ensureVCF();
-        return modules.getNodes().filterNode;
+        audioEngine.ensureVCF();
+        return audioEngine.getNodes().filterNode;
     };
 
     const getNoiseOutputNode = () => {
-        modules.ensureNoise();
-        return modules.getNodes().noiseOutGain;
+        audioEngine.ensureNoise();
+        return audioEngine.getNodes().noiseOutGain;
     };
 
     const getMixerOutputNode = () => {
-        modules.ensureMixer();
-        return modules.getNodes().mixerNode;
+        audioEngine.ensureMixer();
+        return audioEngine.getNodes().mixerNode;
     };
 
     const setMasterOutputNode = node => {
@@ -103,59 +102,59 @@ export const useSynthStore = defineStore('synth', () => {
     const getMasterOutputNode = () => masterOutputNode.value;
 
     const getLFOOutputNode = () => {
-        modules.ensureLFO();
-        return modules.getNodes().lfoOutGain;
+        audioEngine.ensureLFO();
+        return audioEngine.getNodes().lfoOutGain;
     };
 
     const getLFOInputNode = () => {
-        modules.ensureLFO();
-        return modules.getNodes().lfoOsc?.frequency || null;
+        audioEngine.ensureLFO();
+        return audioEngine.getNodes().lfoOsc?.frequency || null;
     };
 
     const getInverterInputNode = () => {
-        modules.ensureInverter();
-        return modules.getNodes().inverterGain;
+        audioEngine.ensureInverter();
+        return audioEngine.getNodes().inverterGain;
     };
 
     const getInverterOutputNode = () => {
-        modules.ensureInverter();
-        return modules.getNodes().inverterGain;
+        audioEngine.ensureInverter();
+        return audioEngine.getNodes().inverterGain;
     };
 
     const getEnvelopeTriggerInputNode = () => {
-        modules.ensureEnvelopeTrigger();
-        return modules.getNodes().envelopeTriggerGain?.gain || null;
+        audioEngine.ensureEnvelopeTrigger();
+        return audioEngine.getNodes().envelopeTriggerGain?.gain || null;
     };
 
     // === Parameter Actions ===
 
     const setVcoFrequency = val => {
         vcoFrequency.value = val;
-        modules.ensureVCO();
-        modules
+        audioEngine.ensureVCO();
+        audioEngine
             .getNodes()
             .vcoOsc?.frequency.setValueAtTime(val, ctx.currentTime);
     };
 
     const setVcoWaveform = val => {
         vcoWaveform.value = val;
-        modules.ensureVCO();
-        const {vcoOsc} = modules.getNodes();
+        audioEngine.ensureVCO();
+        const {vcoOsc} = audioEngine.getNodes();
         if (vcoOsc) vcoOsc.type = val;
     };
 
     const setLfoFrequency = val => {
         lfoFrequency.value = val;
-        modules.ensureLFO();
-        modules
+        audioEngine.ensureLFO();
+        audioEngine
             .getNodes()
             .lfoOsc?.frequency.setValueAtTime(val, ctx.currentTime);
     };
 
     const setLfoWaveform = val => {
         lfoWaveform.value = val;
-        modules.ensureLFO();
-        const {lfoOsc} = modules.getNodes();
+        audioEngine.ensureLFO();
+        const {lfoOsc} = audioEngine.getNodes();
         if (lfoOsc) lfoOsc.type = val;
     };
 
@@ -167,8 +166,8 @@ export const useSynthStore = defineStore('synth', () => {
     const setFilterCutoff = val => {
         const clamped = Math.max(FILTER_MIN_FREQ, val);
         filterCutoff.value = clamped;
-        modules.ensureVCF();
-        const {filterNode} = modules.getNodes();
+        audioEngine.ensureVCF();
+        const {filterNode} = audioEngine.getNodes();
         filterNode?.frequency.setValueAtTime(clamped, ctx.currentTime);
         if (!filterNode) {
             return;
@@ -182,8 +181,8 @@ export const useSynthStore = defineStore('synth', () => {
     const setFilterResonance = val => {
         const clamped = Math.min(FILTER_MAX_Q, Math.max(FILTER_MIN_Q, val));
         filterResonance.value = clamped;
-        modules.ensureVCF();
-        const {filterNode} = modules.getNodes();
+        audioEngine.ensureVCF();
+        const {filterNode} = audioEngine.getNodes();
         filterNode?.Q.setValueAtTime(clamped, ctx.currentTime);
         if (!filterNode) {
             return;
@@ -196,8 +195,8 @@ export const useSynthStore = defineStore('synth', () => {
 
     const setFilterType = val => {
         filterType.value = val;
-        modules.ensureVCF();
-        const {filterNode} = modules.getNodes();
+        audioEngine.ensureVCF();
+        const {filterNode} = audioEngine.getNodes();
         if (filterNode) {
             filterNode.type = val;
         }
@@ -206,17 +205,17 @@ export const useSynthStore = defineStore('synth', () => {
     const setMixerLevels = (vcoLvl, noiseLvl) => {
         vcoLevel.value = vcoLvl;
         noiseLevel.value = noiseLvl;
-        modules.ensureVCO();
-        modules.ensureNoise();
-        const nodes = modules.getNodes();
+        audioEngine.ensureVCO();
+        audioEngine.ensureNoise();
+        const nodes = audioEngine.getNodes();
         nodes.vcoOutGain?.gain.setValueAtTime(vcoLvl, ctx.currentTime);
         nodes.noiseOutGain?.gain.setValueAtTime(noiseLvl, ctx.currentTime);
     };
 
     const setVcaMode = mode => {
         vcaMode.value = mode;
-        modules.ensureLFO();
-        modules
+        audioEngine.ensureLFO();
+        audioEngine
             .getNodes()
             .lfoOutGain?.gain.setValueAtTime(mode, ctx.currentTime);
     };
@@ -265,8 +264,8 @@ export const useSynthStore = defineStore('synth', () => {
 
     // === Envelope Action ===
     const triggerVCAEnvelope = () => {
-        modules.ensureVCA();
-        const {triggerEnvelope} = modules.getNodes();
+        audioEngine.ensureVCA();
+        const {triggerEnvelope} = audioEngine.getNodes();
         if (!triggerEnvelope) return;
 
         const peak = 1 - vcaMode.value;
@@ -277,8 +276,10 @@ export const useSynthStore = defineStore('synth', () => {
         });
     };
 
-    const destroySynth = () => {
-        modules.destroyAll();
+    const destroySynth = async () => {
+        audioEngine.destroyAll();
+        await ctx.close();
+        resetDefaultAudioContext();
     };
 
     return {

--- a/tests/audio/AudioEngine.test.js
+++ b/tests/audio/AudioEngine.test.js
@@ -1,6 +1,5 @@
-import {describe, it, expect, beforeEach, vi} from 'vitest';
-import {setActivePinia, createPinia} from 'pinia';
-import {ref} from 'vue';
+import {describe, it, expect, beforeEach, afterEach, vi} from 'vitest';
+import {AudioEngine} from '/src/audio/AudioEngine';
 
 globalThis.requestAnimationFrame = vi.fn(() => 1);
 globalThis.cancelAnimationFrame = vi.fn();
@@ -20,6 +19,7 @@ const ctx = {
 
 const engine = {
     context: ctx,
+    resume: vi.fn(),
     createFilterNode: vi.fn(() => ({
         connect: vi.fn(),
         disconnect: vi.fn(),
@@ -40,36 +40,21 @@ const engine = {
     })),
 };
 
-vi.mock('../../src/composables/useSynthEngine.js', () => ({
-    useSynthEngine: () => engine,
-}));
-
-vi.mock('../../src/storage/synthStore.js', () => ({
-    useSynthStore: () => ({
-        filterType: ref('lowpass'),
-        filterCutoff: ref(800),
-        filterResonance: ref(1),
-        vcoFrequency: ref(440),
-        vcoWaveform: ref('sawtooth'),
-        lfoFrequency: ref(5),
-        lfoWaveform: ref('sine'),
-    }),
-}));
-
-import {useModuleStore} from '../../src/storage/moduleStore.js';
-
-describe('moduleStore', () => {
-    let modules;
+describe('AudioEngine', () => {
+    let audio;
 
     beforeEach(() => {
-        setActivePinia(createPinia());
-        modules = useModuleStore();
         vi.clearAllMocks();
+        audio = new AudioEngine({}, engine);
+    });
+
+    afterEach(() => {
+        audio.destroyAll();
     });
 
     it('creates nodes lazily', () => {
-        modules.ensureVCO();
-        modules.ensureVCO();
+        audio.ensureVCO();
+        audio.ensureVCO();
 
         expect(engine.createOscillatorNode).toHaveBeenCalledTimes(1);
         expect(engine.createEnvelopeGain).toHaveBeenCalledTimes(1);
@@ -77,11 +62,11 @@ describe('moduleStore', () => {
     });
 
     it('destroys nodes and allows reinitialisation', () => {
-        modules.ensureVCO();
-        modules.ensureLFO();
-        const nodes = modules.getNodes();
+        audio.ensureVCO();
+        audio.ensureLFO();
+        const nodes = audio.getNodes();
 
-        modules.destroyAll();
+        audio.destroyAll();
 
         expect(nodes.vcoOsc.stop).toHaveBeenCalled();
         expect(nodes.vcoOsc.disconnect).toHaveBeenCalled();
@@ -89,13 +74,12 @@ describe('moduleStore', () => {
         expect(nodes.lfoOsc.disconnect).toHaveBeenCalled();
         expect(nodes.vcoOutGain.disconnect).toHaveBeenCalled();
         expect(nodes.lfoOutGain.disconnect).toHaveBeenCalled();
-        expect(globalThis.cancelAnimationFrame).toHaveBeenCalled();
-        const cleared = modules.getNodes();
+        const cleared = audio.getNodes();
         expect(cleared.vcoOsc).toBeNull();
         expect(cleared.lfoOsc).toBeNull();
 
         engine.createOscillatorNode.mockClear();
-        modules.ensureVCO();
+        audio.ensureVCO();
         expect(engine.createOscillatorNode).toHaveBeenCalledTimes(1);
     });
 });

--- a/tests/composables/useSynthEngine.test.js
+++ b/tests/composables/useSynthEngine.test.js
@@ -1,5 +1,5 @@
 import {describe, it, expect} from 'vitest';
-import {useSynthEngine} from '../../src/composables/useSynthEngine.js';
+import {useSynthEngine} from '@/composables/useSynthEngine';
 
 class FakeAudioContext {
     constructor() {

--- a/tests/stores/SynthStore.test.js
+++ b/tests/stores/SynthStore.test.js
@@ -8,6 +8,7 @@ const ctx = {
         ctx.state = 'running';
         return Promise.resolve();
     }),
+    close: vi.fn(() => Promise.resolve()),
 };
 
 const createNodes = () => ({
@@ -31,25 +32,26 @@ const createNodes = () => ({
 });
 
 let nodes;
-const modules = {
+const audioEngine = {
+    context: ctx,
+    resume: vi.fn(() => ctx.resume()),
     ensureVCO: vi.fn(),
     ensureVCF: vi.fn(),
     ensureVCA: vi.fn(),
     ensureNoise: vi.fn(),
     ensureLFO: vi.fn(),
+    ensureMixer: vi.fn(),
+    ensureInverter: vi.fn(),
+    ensureEnvelopeTrigger: vi.fn(),
     getNodes: () => nodes,
     destroyAll: vi.fn(),
 };
 
-vi.mock('../../src/composables/useSynthEngine.js', () => ({
-    useSynthEngine: () => ({context: ctx}),
+vi.mock('../../src/audio/AudioEngine.js', () => ({
+    AudioEngine: vi.fn(() => audioEngine),
 }));
 
-vi.mock('../../src/storage/moduleStore.js', () => ({
-    useModuleStore: () => modules,
-}));
-
-import {useSynthStore, DEFAULTS} from '../../src/storage/synthStore.js';
+import {useSynthStore, DEFAULTS} from '@/storage/synthStore';
 
 describe('synthStore', () => {
     let synth;
@@ -70,7 +72,7 @@ describe('synthStore', () => {
     it('sets VCO frequency', () => {
         synth.setVcoFrequency(880);
         expect(synth.vcoFrequency).toBe(880);
-        expect(modules.ensureVCO).toHaveBeenCalled();
+        expect(audioEngine.ensureVCO).toHaveBeenCalled();
         expect(nodes.vcoOsc.frequency.setValueAtTime).toHaveBeenCalledWith(
             880,
             ctx.currentTime
@@ -80,7 +82,7 @@ describe('synthStore', () => {
     it('clamps filter cutoff and schedules changes', () => {
         synth.setFilterCutoff(10);
         expect(synth.filterCutoff).toBe(20);
-        expect(modules.ensureVCF).toHaveBeenCalled();
+        expect(audioEngine.ensureVCF).toHaveBeenCalled();
         expect(nodes.filterNode.frequency.setValueAtTime).toHaveBeenCalledWith(
             20,
             ctx.currentTime
@@ -96,8 +98,8 @@ describe('synthStore', () => {
         synth.setMixerLevels(0.5, 0.3);
         expect(synth.vcoLevel).toBe(0.5);
         expect(synth.noiseLevel).toBe(0.3);
-        expect(modules.ensureVCO).toHaveBeenCalled();
-        expect(modules.ensureNoise).toHaveBeenCalled();
+        expect(audioEngine.ensureVCO).toHaveBeenCalled();
+        expect(audioEngine.ensureNoise).toHaveBeenCalled();
         expect(nodes.vcoOutGain.gain.setValueAtTime).toHaveBeenCalledWith(
             0.5,
             ctx.currentTime
@@ -117,7 +119,7 @@ describe('synthStore', () => {
 
     it('triggers envelope', () => {
         synth.triggerEnvelope();
-        expect(modules.ensureVCA).toHaveBeenCalled();
+        expect(audioEngine.ensureVCA).toHaveBeenCalled();
         expect(nodes.triggerEnvelope).toHaveBeenCalledWith({
             attack: synth.envelopeAttack,
             decay: synth.envelopeDecay,
@@ -125,8 +127,8 @@ describe('synthStore', () => {
         });
     });
 
-    it('destroys synth', () => {
-        synth.destroySynth();
-        expect(modules.destroyAll).toHaveBeenCalled();
+    it('destroys synth', async () => {
+        await synth.destroySynth();
+        expect(audioEngine.destroyAll).toHaveBeenCalled();
     });
 });


### PR DESCRIPTION
Replaced the global module store with a new AudioEngine class that manages audio context, node creation, and cleanup, enabling multiple synth instances and easier testing

Updated the synth store to instantiate AudioEngine, routing node access and parameter actions through this encapsulated API instead of the previous global store